### PR TITLE
Feature/39-86et8hecn dynamic theme from api

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ export default App;
   - `botProviderEndpoint?`: `string` - Bot provider endpoint URL
   - `onExecutionError?`: `(error: ErrorEventData) => void` - Error handler for execution errors
   - `transformSsePayload?`: `(payload: FetchSsePayload) => FetchSsePayload` - SSE payload transformer
-- `enableLoadConfigFromService?`: `boolean` - Enable loading configuration from service
-- `loadingComponent?`: `ReactNode` - Custom loading component
+- **enableLoadConfigFromService?**: `boolean` - Enable loading configuration from service
+- **loadingComponent?**: `ReactNode` - Custom loading component
+- **asyncInitializers?**: `Record<string, () => Promise<unknown>>` - Asynchronous initializers for app initialization before rendering any component. Good for loading data or other async operations as the initial state. It only works when `enableLoadConfigFromService` is set to `true`.
 - **customChannelId**: `string` - Custom channel identifier for the chat session
 - **initMessages**: `ConversationMessage[]` - Initial messages to display in the chat
 - **debugMode**: `boolean` - Enable debug mode, defaults to `false`

--- a/README.md
+++ b/README.md
@@ -24,14 +24,16 @@ const App = () => {
       title="Asgard AI Chatbot"
       config={{
         apiKey: 'your-api-key',
-        endpoint: 'https://api.asgard-ai.com',
+        endpoint: 'https://api.asgard-ai.com/ns/{namespace}/bot-provider/{botProviderId}/message/sse',
+        botProviderEndpoint: 'https://api.asgard-ai.com/ns/{namespace}/bot-provider/{botProviderId}',
         onExecutionError: (error) => {
           console.error('Execution error:', error);
         },
         transformSsePayload: (payload) => {
           return payload;
-        },
+        }
       }}
+      enableLoadConfigFromService={true}
       customChannelId="your-channel-id"
       initMessages={[]}
       debugMode={false}
@@ -57,8 +59,11 @@ export default App;
 - **config**: `ClientConfig` - Configuration object for the Asgard service client, including:
   - `apiKey`: `string` (required) - API key for authentication
   - `endpoint`: `string` (required) - API endpoint URL
+  - `botProviderEndpoint?`: `string` - Bot provider endpoint URL
   - `onExecutionError?`: `(error: ErrorEventData) => void` - Error handler for execution errors
   - `transformSsePayload?`: `(payload: FetchSsePayload) => FetchSsePayload` - SSE payload transformer
+- `enableLoadConfigFromService?`: `boolean` - Enable loading configuration from service
+- `loadingComponent?`: `ReactNode` - Custom loading component
 - **customChannelId**: `string` - Custom channel identifier for the chat session
 - **initMessages**: `ConversationMessage[]` - Initial messages to display in the chat
 - **debugMode**: `boolean` - Enable debug mode, defaults to `false`
@@ -70,6 +75,12 @@ export default App;
 - **onClose**: `() => void` - Callback function when chat is closed
 
 ### Theme Configuration
+The theme configuration can be obtained from the bot provider metadata of `annotations` field and `theme` props.
+
+The priority of themes is as follows (high to low):
+1. Theme from props
+2. Theme from annotations from bot provider metadata
+3. Default theme
 
 ```typescript
 interface AsgardThemeContextValue {
@@ -118,7 +129,7 @@ const defaultTheme = {
     color: 'var(--asg-color-text)',
     backgroundColor: 'var(--asg-color-primary)',
   },
-};
+}
 ```
 
 ### Usage Example

--- a/apps/react-demo/src/pages/root.tsx
+++ b/apps/react-demo/src/pages/root.tsx
@@ -10,7 +10,8 @@ import {
   // createImageTemplateExample,
 } from './const';
 
-const { VITE_ENDPOINT, VITE_API_KEY } = import.meta.env;
+const { VITE_ENDPOINT, VITE_API_KEY, VITE_BOT_PROVIDER_ENDPOINT } = import.meta
+  .env;
 
 export function Root(): ReactNode {
   const [customChannelId] = useState(crypto.randomUUID());
@@ -32,9 +33,11 @@ export function Root(): ReactNode {
         title="Chatbot"
         config={{
           endpoint: VITE_ENDPOINT,
+          botProviderEndpoint: VITE_BOT_PROVIDER_ENDPOINT,
           apiKey: VITE_API_KEY,
         }}
         avatar="./showtime.webp"
+        enableLoadConfigFromService={true}
         botTypingPlaceholder="typing"
         customChannelId={customChannelId}
         initMessages={initMessages}

--- a/apps/react-demo/src/pages/root.tsx
+++ b/apps/react-demo/src/pages/root.tsx
@@ -38,6 +38,7 @@ export function Root(): ReactNode {
         }}
         avatar="./showtime.webp"
         enableLoadConfigFromService={true}
+        loadingComponent={<div>Custom Loading...</div>}
         botTypingPlaceholder="typing"
         customChannelId={customChannelId}
         initMessages={initMessages}

--- a/packages/core/src/types/client.ts
+++ b/packages/core/src/types/client.ts
@@ -30,6 +30,7 @@ export interface SseHandlers {
 
 export interface ClientConfig extends SseHandlers {
   endpoint: string;
+  botProviderEndpoint?: string;
   apiKey?: string;
   debugMode?: boolean;
   transformSsePayload?: (payload: FetchSsePayload) => FetchSsePayload;

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -62,8 +62,9 @@ export default App;
   - `botProviderEndpoint?`: `string` - Bot provider endpoint URL
   - `onExecutionError?`: `(error: ErrorEventData) => void` - Error handler for execution errors
   - `transformSsePayload?`: `(payload: FetchSsePayload) => FetchSsePayload` - SSE payload transformer
-- `enableLoadConfigFromService?`: `boolean` - Enable loading configuration from service
-- `loadingComponent?`: `ReactNode` - Custom loading component
+- **enableLoadConfigFromService?**: `boolean` - Enable loading configuration from service
+- **loadingComponent?**: `ReactNode` - Custom loading component
+- **asyncInitializers?**: `Record<string, () => Promise<unknown>>` - Asynchronous initializers for app initialization before rendering any component. Good for loading data or other async operations as the initial state. It only works when `enableLoadConfigFromService` is set to `true`.
 - **customChannelId**: `string` - Custom channel identifier for the chat session
 - **initMessages**: `ConversationMessage[]` - Initial messages to display in the chat
 - **debugMode**: `boolean` - Enable debug mode, defaults to `false`

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -24,7 +24,8 @@ const App = () => {
       title="Asgard AI Chatbot"
       config={{
         apiKey: 'your-api-key',
-        endpoint: 'https://api.asgard-ai.com',
+        endpoint: 'https://api.asgard-ai.com/ns/{namespace}/bot-provider/{botProviderId}/message/sse',
+        botProviderEndpoint: 'https://api.asgard-ai.com/ns/{namespace}/bot-provider/{botProviderId}',
         onExecutionError: (error) => {
           console.error('Execution error:', error);
         },
@@ -32,6 +33,7 @@ const App = () => {
           return payload;
         }
       }}
+      enableLoadConfigFromService={true}
       customChannelId="your-channel-id"
       initMessages={[]}
       debugMode={false}
@@ -57,8 +59,10 @@ export default App;
 - **config**: `ClientConfig` - Configuration object for the Asgard service client, including:
   - `apiKey`: `string` (required) - API key for authentication
   - `endpoint`: `string` (required) - API endpoint URL
+  - `botProviderEndpoint?`: `string` - Bot provider endpoint URL
   - `onExecutionError?`: `(error: ErrorEventData) => void` - Error handler for execution errors
   - `transformSsePayload?`: `(payload: FetchSsePayload) => FetchSsePayload` - SSE payload transformer
+- `enableLoadConfigFromService?`: `boolean` - Enable loading configuration from service
 - **customChannelId**: `string` - Custom channel identifier for the chat session
 - **initMessages**: `ConversationMessage[]` - Initial messages to display in the chat
 - **debugMode**: `boolean` - Enable debug mode, defaults to `false`
@@ -70,6 +74,12 @@ export default App;
 - **onClose**: `() => void` - Callback function when chat is closed
 
 ### Theme Configuration
+The theme configuration can be obtained from the bot provider metadata of `annotations` field and `theme` props.
+
+The priority of themes is as follows (high to low):
+1. Theme from props
+2. Theme from annotations from bot provider metadata
+3. Default theme
 
 ```typescript
 interface AsgardThemeContextValue {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -63,6 +63,7 @@ export default App;
   - `onExecutionError?`: `(error: ErrorEventData) => void` - Error handler for execution errors
   - `transformSsePayload?`: `(payload: FetchSsePayload) => FetchSsePayload` - SSE payload transformer
 - `enableLoadConfigFromService?`: `boolean` - Enable loading configuration from service
+- `loadingComponent?`: `ReactNode` - Custom loading component
 - **customChannelId**: `string` - Custom channel identifier for the chat session
 - **initMessages**: `ConversationMessage[]` - Initial messages to display in the chat
 - **debugMode**: `boolean` - Enable debug mode, defaults to `false`

--- a/packages/react/src/components/chatbot/chatbot.tsx
+++ b/packages/react/src/components/chatbot/chatbot.tsx
@@ -8,6 +8,7 @@ import {
   AsgardServiceContextProvider,
   AsgardTemplateContextProvider,
   AsgardTemplateContextValue,
+  AsgardAppInitializationContextProvider,
 } from 'src/context';
 import { ChatbotHeader } from './chatbot-header';
 import { ChatbotBody } from './chatbot-body';
@@ -24,6 +25,7 @@ interface ChatbotProps extends AsgardTemplateContextValue {
   fullScreen?: boolean;
   avatar?: string;
   botTypingPlaceholder?: string;
+  enableLoadConfigFromService?: boolean;
   onReset?: () => void;
   onClose?: () => void;
 }
@@ -39,6 +41,7 @@ export function Chatbot(props: ChatbotProps): ReactNode {
     fullScreen = false,
     avatar,
     botTypingPlaceholder,
+    enableLoadConfigFromService = false,
     onReset,
     onClose,
     onErrorClick,
@@ -46,30 +49,35 @@ export function Chatbot(props: ChatbotProps): ReactNode {
   } = props;
 
   return (
-    <AsgardThemeContextProvider theme={theme}>
-      <AsgardServiceContextProvider
-        avatar={avatar}
-        config={config}
-        customChannelId={customChannelId}
-        initMessages={initMessages}
-        botTypingPlaceholder={botTypingPlaceholder}
-      >
-        <ChatbotContainer fullScreen={fullScreen}>
-          <ChatbotHeader
-            title={title}
-            onReset={onReset}
-            onClose={onClose}
-            customActions={customActions}
-          />
-          <AsgardTemplateContextProvider
-            onErrorClick={onErrorClick}
-            errorMessageRenderer={errorMessageRenderer}
-          >
-            <ChatbotBody />
-          </AsgardTemplateContextProvider>
-          <ChatbotFooter />
-        </ChatbotContainer>
-      </AsgardServiceContextProvider>
-    </AsgardThemeContextProvider>
+    <AsgardAppInitializationContextProvider
+      enabled={enableLoadConfigFromService}
+      asyncInitializers={{}}
+    >
+      <AsgardThemeContextProvider theme={theme}>
+        <AsgardServiceContextProvider
+          avatar={avatar}
+          config={config}
+          customChannelId={customChannelId}
+          initMessages={initMessages}
+          botTypingPlaceholder={botTypingPlaceholder}
+        >
+          <ChatbotContainer fullScreen={fullScreen}>
+            <ChatbotHeader
+              title={title}
+              onReset={onReset}
+              onClose={onClose}
+              customActions={customActions}
+            />
+            <AsgardTemplateContextProvider
+              onErrorClick={onErrorClick}
+              errorMessageRenderer={errorMessageRenderer}
+            >
+              <ChatbotBody />
+            </AsgardTemplateContextProvider>
+            <ChatbotFooter />
+          </ChatbotContainer>
+        </AsgardServiceContextProvider>
+      </AsgardThemeContextProvider>
+    </AsgardAppInitializationContextProvider>
   );
 }

--- a/packages/react/src/components/chatbot/chatbot.tsx
+++ b/packages/react/src/components/chatbot/chatbot.tsx
@@ -26,6 +26,7 @@ interface ChatbotProps extends AsgardTemplateContextValue {
   avatar?: string;
   botTypingPlaceholder?: string;
   enableLoadConfigFromService?: boolean;
+  asyncInitializers?: Record<string, () => Promise<unknown>>;
   onReset?: () => void;
   onClose?: () => void;
 }
@@ -42,6 +43,7 @@ export function Chatbot(props: ChatbotProps): ReactNode {
     avatar,
     botTypingPlaceholder,
     enableLoadConfigFromService = false,
+    asyncInitializers = {},
     onReset,
     onClose,
     onErrorClick,
@@ -51,7 +53,8 @@ export function Chatbot(props: ChatbotProps): ReactNode {
   return (
     <AsgardAppInitializationContextProvider
       enabled={enableLoadConfigFromService}
-      asyncInitializers={{}}
+      config={config}
+      asyncInitializers={asyncInitializers}
     >
       <AsgardThemeContextProvider theme={theme}>
         <AsgardServiceContextProvider

--- a/packages/react/src/components/chatbot/chatbot.tsx
+++ b/packages/react/src/components/chatbot/chatbot.tsx
@@ -29,6 +29,7 @@ interface ChatbotProps extends AsgardTemplateContextValue {
   asyncInitializers?: Record<string, () => Promise<unknown>>;
   onReset?: () => void;
   onClose?: () => void;
+  loadingComponent?: ReactNode;
 }
 
 export function Chatbot(props: ChatbotProps): ReactNode {
@@ -44,6 +45,7 @@ export function Chatbot(props: ChatbotProps): ReactNode {
     botTypingPlaceholder,
     enableLoadConfigFromService = false,
     asyncInitializers = {},
+    loadingComponent,
     onReset,
     onClose,
     onErrorClick,
@@ -55,6 +57,7 @@ export function Chatbot(props: ChatbotProps): ReactNode {
       enabled={enableLoadConfigFromService}
       config={config}
       asyncInitializers={asyncInitializers}
+      loadingComponent={loadingComponent}
     >
       <AsgardThemeContextProvider theme={theme}>
         <AsgardServiceContextProvider

--- a/packages/react/src/context/asgard-app-initialization-context.tsx
+++ b/packages/react/src/context/asgard-app-initialization-context.tsx
@@ -1,0 +1,99 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  PropsWithChildren,
+  ReactNode,
+} from 'react';
+
+type AsyncInitializers = {
+  [key: string]: () => Promise<any>;
+};
+
+export interface AsgardAppInitializationContextValue {
+  data: Record<string, any>;
+  loading: boolean;
+  error: Error | null;
+}
+
+export const AsgardAppInitializationContext =
+  createContext<AsgardAppInitializationContextValue>({
+    data: {},
+    loading: true,
+    error: null,
+  });
+
+export interface AsgardAppInitializationContextProviderProps {
+  enabled: boolean;
+  asyncInitializers: AsyncInitializers;
+  loadingComponent?: React.ReactNode;
+}
+
+export const AsgardAppInitializationContextProvider = (
+  props: PropsWithChildren<AsgardAppInitializationContextProviderProps>
+): ReactNode => {
+  const {
+    enabled,
+    asyncInitializers,
+    children,
+    loadingComponent = <div>Loading...</div>,
+  } = props;
+
+  const [data, setData] = useState<Record<string, any>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (!enabled) {
+      return;
+    }
+
+    setLoading(true);
+
+    Promise.all(
+      Object.entries(asyncInitializers).map(async ([key, fn]) => {
+        try {
+          const value = await fn();
+
+          return [key, value];
+        } catch (e) {
+          return [key, undefined];
+        }
+      })
+    )
+      .then((results) => {
+        if (isMounted) setData(Object.fromEntries(results));
+      })
+      .catch((err) => {
+        if (isMounted) setError(err);
+      })
+      .finally(() => {
+        if (isMounted) setLoading(false);
+      });
+
+    return (): void => {
+      isMounted = false;
+    };
+  }, [asyncInitializers, enabled]);
+
+  if (!enabled) {
+    return children;
+  }
+
+  if (loading) {
+    return loadingComponent;
+  }
+
+  return (
+    <AsgardAppInitializationContext.Provider value={{ data, loading, error }}>
+      {children}
+    </AsgardAppInitializationContext.Provider>
+  );
+};
+
+export const useAsgardAppInitializationContext =
+  (): AsgardAppInitializationContextValue =>
+    useContext(AsgardAppInitializationContext);

--- a/packages/react/src/context/asgard-app-initialization-context.tsx
+++ b/packages/react/src/context/asgard-app-initialization-context.tsx
@@ -16,8 +16,20 @@ type AsyncInitializers = {
   [key: string]: () => Promise<unknown>;
 };
 
+export interface Annotations {
+  embedConfig: {
+    theme: {
+      chatbot: Record<string, unknown>;
+      botMessage: Record<string, unknown>;
+      userMessage: Record<string, unknown>;
+    };
+  };
+}
+
 export interface AsgardAppInitializationContextValue {
-  data: Record<string, unknown>;
+  data: {
+    annotations?: Annotations;
+  };
   loading: boolean;
   error: Error | null;
 }
@@ -54,13 +66,15 @@ export const AsgardAppInitializationContextProvider = (
   const asyncInitializers = useMemo(
     () =>
       deepMerge(
-        { theme: botProviderModels.getAsgardBotProviderMetadata },
+        { annotations: botProviderModels.getAnnotations },
         asyncInitializersFromProp
       ),
     [asyncInitializersFromProp, botProviderModels]
   );
 
-  const [data, setData] = useState<Record<string, unknown>>({});
+  const [data, setData] = useState<AsgardAppInitializationContextValue['data']>(
+    {}
+  );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 

--- a/packages/react/src/context/index.ts
+++ b/packages/react/src/context/index.ts
@@ -1,3 +1,4 @@
 export * from './asgard-service-context';
 export * from './asgard-template-context';
 export * from './asgard-theme-context';
+export * from './asgard-app-initialization-context';

--- a/packages/react/src/models/bot-provider.ts
+++ b/packages/react/src/models/bot-provider.ts
@@ -1,4 +1,5 @@
 import { ClientConfig } from '@asgard-js/core';
+import { annotationSelectorFromBotProviderMetadata } from '../utils/selectors';
 
 export type BotProviderMetadataResponse = {
   name: string;
@@ -15,7 +16,7 @@ export type BotProviderMetadataResponse = {
     apiVersion: string;
     time: string;
     fieldsType: string;
-    fieldsV1: Record<string, any>;
+    fieldsV1: Record<string, unknown>;
     subresource: string;
   }>;
 };
@@ -24,6 +25,7 @@ export const getBotProviderModels = (
   config: ClientConfig
 ): {
   getAsgardBotProviderMetadata: () => Promise<BotProviderMetadataResponse>;
+  getAnnotations: () => Promise<Record<string, unknown>>;
 } => {
   if (!config.botProviderEndpoint) {
     throw new Error('Bot provider endpoint is not defined in the config');
@@ -53,7 +55,14 @@ export const getBotProviderModels = (
     return json.data;
   }
 
+  async function getAnnotations(): Promise<Record<string, unknown>> {
+    const metadata = await getAsgardBotProviderMetadata();
+
+    return annotationSelectorFromBotProviderMetadata(metadata);
+  }
+
   return {
     getAsgardBotProviderMetadata,
+    getAnnotations,
   };
 };

--- a/packages/react/src/models/bot-provider.ts
+++ b/packages/react/src/models/bot-provider.ts
@@ -1,0 +1,59 @@
+import { ClientConfig } from '@asgard-js/core';
+
+export type BotProviderMetadataResponse = {
+  name: string;
+  namespace: string;
+  uid: string;
+  resourceVersion: string;
+  generation: number;
+  creationTimestamp: string;
+  labels: Record<string, string>;
+  annotations: Record<string, string>;
+  managedFields: Array<{
+    manager: string;
+    operation: string;
+    apiVersion: string;
+    time: string;
+    fieldsType: string;
+    fieldsV1: Record<string, any>;
+    subresource: string;
+  }>;
+};
+
+export const getBotProviderModels = (
+  config: ClientConfig
+): {
+  getAsgardBotProviderMetadata: () => Promise<BotProviderMetadataResponse>;
+} => {
+  if (!config.botProviderEndpoint) {
+    throw new Error('Bot provider endpoint is not defined in the config');
+  }
+
+  const headers: Record<string, string> = {};
+
+  if (config.apiKey) {
+    headers['x-api-key'] = config.apiKey;
+  }
+
+  async function getAsgardBotProviderMetadata(): Promise<BotProviderMetadataResponse> {
+    const response = await fetch(`${config.botProviderEndpoint}/metadata`, {
+      method: 'GET',
+      headers: {
+        ...headers,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch metadata: ${response.statusText}`);
+    }
+
+    const json: { data: BotProviderMetadataResponse } = await response.json();
+
+    return json.data;
+  }
+
+  return {
+    getAsgardBotProviderMetadata,
+  };
+};

--- a/packages/react/src/utils/selectors.ts
+++ b/packages/react/src/utils/selectors.ts
@@ -1,0 +1,7 @@
+import { BotProviderMetadataResponse } from '../models/bot-provider';
+
+export const annotationSelectorFromBotProviderMetadata = (
+  value: BotProviderMetadataResponse
+): Record<string, unknown> => {
+  return JSON.parse(value.annotations['asgard-ai.com/additional-annotation']);
+};


### PR DESCRIPTION
re #39

## Description
Add three new props, `enableLoadConfigFromService`, `loadingComponent` and `asyncInitializers`,  and a new option, `botProviderEndpoint`, for `config` props from `Chatbot` component of `react` package.

- **enableLoadConfigFromService?**: `boolean` - Enable loading configuration from service
- **loadingComponent?**: `ReactNode` - Custom loading component
- **asyncInitializers?**: `Record<string, () => Promise<unknown>>` - Asynchronous initializers for app initialization before rendering any component. Good for loading data or other async operations as the initial state. It only works when `enableLoadConfigFromService` is set to `true`.
- **config**: `ClientConfig` - Configuration object for the Asgard service client, including:
  - `apiKey`: `string` (required) - API key for authentication
  - `endpoint`: `string` (required) - API endpoint URL
  - `botProviderEndpoint?`: `string` - Bot provider endpoint URL
  - `onExecutionError?`: `(error: ErrorEventData) => void` - Error handler for execution errors
  - `transformSsePayload?`: `(payload: FetchSsePayload) => FetchSsePayload` - SSE payload transformer

The theme configuration can be obtained from the bot provider metadata of `annotations` field and `theme` props.

The priority of themes is as follows (high to low):
1. Theme from props
2. Theme from annotations from bot provider metadata
3. Default theme

## Preview
https://drive.google.com/file/d/1doMYe98a7SBp4QJciftRnCPJ1EHC4rmm/view?usp=drive_link
