### PR TITLE
Feature/86etdh7j0 support proactively sending SSE messages by exporting `ref` and `onSseMessage` callback

### DIFF
--- a/apps/react-demo/src/pages/root.tsx
+++ b/apps/react-demo/src/pages/root.tsx
@@ -1,5 +1,5 @@
-import { Chatbot } from '@asgard-js/react';
-import { ReactNode, useState } from 'react';
+import { Chatbot, ChatbotRef } from '@asgard-js/react';
+import { ReactNode, useRef, useState } from 'react';
 import { ConversationMessage } from '@asgard-js/core';
 import {
   // createButtonTemplateExample,
@@ -26,9 +26,32 @@ export function Root(): ReactNode {
     // createImageTemplateExample(600, 400),
   ]);
 
+  const chatbotRef = useRef<ChatbotRef>(null);
+
   return (
-    <div style={{ width: '800px' }}>
+    <div style={{ width: '800px', position: 'relative' }}>
+      <button
+        style={{
+          position: 'absolute',
+          top: '80px',
+          right: '50%',
+          transform: 'translateX(50%)',
+          zIndex: 10,
+          border: '1px solid white',
+          borderRadius: '5px',
+          color: 'white',
+          backgroundColor: 'transparent',
+          cursor: 'pointer',
+          padding: '0.5rem 1rem',
+        }}
+        onClick={() =>
+          chatbotRef.current?.serviceContext?.sendMessage?.({ text: 'Hello' })
+        }
+      >
+        Send a message from outside of chatbot
+      </button>
       <Chatbot
+        ref={chatbotRef}
         fullScreen
         title="Chatbot"
         config={{
@@ -42,8 +65,17 @@ export function Root(): ReactNode {
         botTypingPlaceholder="typing"
         customChannelId={customChannelId}
         initMessages={initMessages}
-        onTemplateBtnClick={(payload) => {
-          console.log('onTemplateBtnClick', payload);
+        onSseMessage={(response, ctx) => {
+          if (response.eventType === 'asgard.run.done') {
+            console.log('onSseMessage', response, ctx.conversation);
+
+            setTimeout(() => {
+              // delay some time to wait for the serviceContext to be available
+              chatbotRef.current?.serviceContext?.sendMessage?.({
+                text: 'Say hi after 5 seconds',
+              });
+            }, 5000);
+          }
         }}
         theme={{
           chatbot: {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -15,38 +15,77 @@ yarn add @asgard-js/core @asgard-js/react
 Here's a basic example of how to use the React components:
 
 ```javascript
-import React from 'react';
+import React, { useRef } from 'react';
 import { Chatbot } from '@asgard-js/react';
+
+const chatbotRef = useRef(null);
 
 const App = () => {
   return (
-    <Chatbot
-      title="Asgard AI Chatbot"
-      config={{
-        apiKey: 'your-api-key',
-        endpoint: 'https://api.asgard-ai.com/ns/{namespace}/bot-provider/{botProviderId}/message/sse',
-        botProviderEndpoint: 'https://api.asgard-ai.com/ns/{namespace}/bot-provider/{botProviderId}',
-        onExecutionError: (error) => {
-          console.error('Execution error:', error);
-        },
-        transformSsePayload: (payload) => {
-          return payload;
+    <div style={{ width: '800px', position: 'relative' }}>
+      <button
+        style={{
+          position: 'absolute',
+          top: '80px',
+          right: '50%',
+          transform: 'translateX(50%)',
+          zIndex: 10,
+          border: '1px solid white',
+          borderRadius: '5px',
+          color: 'white',
+          backgroundColor: 'transparent',
+          cursor: 'pointer',
+          padding: '0.5rem 1rem',
+        }}
+        onClick={() =>
+          chatbotRef.current?.serviceContext?.sendMessage?.({ text: 'Hello' })
         }
-      }}
-      enableLoadConfigFromService={true}
-      customChannelId="your-channel-id"
-      initMessages={[]}
-      debugMode={false}
-      fullScreen={false}
-      avatar="https://example.com/avatar.png"
-      botTypingPlaceholder="Bot is typing..."
-      onReset={() => {
-        console.log('Chat reset');
-      }}
-      onClose={() => {
-        console.log('Chat closed');
-      }}
-    />
+      >
+        Send a message from outside of chatbot
+      </button>
+      <Chatbot
+        ref={chatbotRef}
+        title="Asgard AI Chatbot"
+        config={{
+          apiKey: 'your-api-key',
+          endpoint:
+            'https://api.asgard-ai.com/ns/{namespace}/bot-provider/{botProviderId}/message/sse',
+          botProviderEndpoint:
+            'https://api.asgard-ai.com/ns/{namespace}/bot-provider/{botProviderId}',
+          onExecutionError: (error) => {
+            console.error('Execution error:', error);
+          },
+          transformSsePayload: (payload) => {
+            return payload;
+          },
+        }}
+        enableLoadConfigFromService={true}
+        customChannelId="your-channel-id"
+        initMessages={[]}
+        debugMode={false}
+        fullScreen={false}
+        avatar="https://example.com/avatar.png"
+        botTypingPlaceholder="Bot is typing..."
+        onReset={() => {
+          console.log('Chat reset');
+        }}
+        onClose={() => {
+          console.log('Chat closed');
+        }}
+        onSseMessage={(response, ctx) => {
+          if (response.eventType === 'asgard.run.done') {
+            console.log('onSseMessage', response, ctx.conversation);
+
+            setTimeout(() => {
+              // delay some time to wait for the serviceContext to be available
+              chatbotRef.current?.serviceContext?.sendMessage?.({
+                text: 'Say hi after 5 seconds',
+              });
+            }, 5000);
+          }
+        }}
+      />
+    </div>
   );
 };
 
@@ -74,11 +113,15 @@ export default App;
 - **theme**: `Partial<AsgardThemeContextValue>` - Custom theme configuration
 - **onReset**: `() => void` - Callback function when chat is reset
 - **onClose**: `() => void` - Callback function when chat is closed
+- **onSseMessage**: `(response: SseResponse, ctx: AsgardServiceContextValue) => void` - Callback function when SSE message is received. It would be helpful if using with the ref to provide some context and conversation data and do some proactively actions like sending messages to the bot.
+- **ref**: `ForwardedRef<ChatbotRef>` - Forwarded ref to access the chatbot instance. It can be used to access the chatbot instance and do some actions like sending messages to the bot. ChatbotRef extends the ref of the chatbot instance and provides some additional methods like `serviceContext.sendMessage` to interact with the chatbot instance.
 
 ### Theme Configuration
+
 The theme configuration can be obtained from the bot provider metadata of `annotations` field and `theme` props.
 
 The priority of themes is as follows (high to low):
+
 1. Theme from props
 2. Theme from annotations from bot provider metadata
 3. Default theme
@@ -228,7 +271,7 @@ const defaultTheme = {
       style: {},
     },
   },
-}
+};
 ```
 
 ### Usage Example
@@ -269,6 +312,7 @@ To develop the React package locally, follow these steps:
 1. Clone the repository and navigate to the project root directory.
 
 2. Install dependencies:
+
 ```sh
 yarn install
 ```

--- a/packages/react/src/components/chatbot/chatbot.tsx
+++ b/packages/react/src/components/chatbot/chatbot.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { forwardRef, ForwardedRef, ReactNode } from 'react';
 import { ClientConfig, ConversationMessage } from '@asgard-js/core';
 import {
   AsgardThemeContextProvider,
@@ -6,6 +6,7 @@ import {
 } from 'src/context/asgard-theme-context';
 import {
   AsgardServiceContextProvider,
+  AsgardServiceContextValue,
   AsgardTemplateContextProvider,
   AsgardTemplateContextValue,
   AsgardAppInitializationContextProvider,
@@ -32,7 +33,14 @@ interface ChatbotProps extends AsgardTemplateContextValue {
   loadingComponent?: ReactNode;
 }
 
-export function Chatbot(props: ChatbotProps): ReactNode {
+export interface ChatbotRef {
+  serviceContext?: AsgardServiceContextValue;
+}
+
+export const Chatbot = forwardRef(function Chatbot(
+  props: ChatbotProps,
+  ref: ForwardedRef<ChatbotRef>
+): ReactNode {
   const {
     title,
     customActions,
@@ -62,6 +70,7 @@ export function Chatbot(props: ChatbotProps): ReactNode {
     >
       <AsgardThemeContextProvider theme={theme}>
         <AsgardServiceContextProvider
+          parentRef={ref}
           avatar={avatar}
           config={config}
           customChannelId={customChannelId}
@@ -88,4 +97,4 @@ export function Chatbot(props: ChatbotProps): ReactNode {
       </AsgardThemeContextProvider>
     </AsgardAppInitializationContextProvider>
   );
-}
+});

--- a/packages/react/src/components/chatbot/chatbot.tsx
+++ b/packages/react/src/components/chatbot/chatbot.tsx
@@ -10,6 +10,7 @@ import {
   AsgardTemplateContextProvider,
   AsgardTemplateContextValue,
   AsgardAppInitializationContextProvider,
+  AsgardServiceContextProviderProps,
 } from 'src/context';
 import { ChatbotHeader } from './chatbot-header';
 import { ChatbotBody } from './chatbot-body';
@@ -23,6 +24,7 @@ interface ChatbotProps extends AsgardTemplateContextValue {
   config: ClientConfig;
   customChannelId: string;
   initMessages?: ConversationMessage[];
+  onSseMessage?: AsgardServiceContextProviderProps['onSseMessage'];
   fullScreen?: boolean;
   avatar?: string;
   botTypingPlaceholder?: string;
@@ -48,6 +50,7 @@ export const Chatbot = forwardRef(function Chatbot(
     config,
     customChannelId,
     initMessages,
+    onSseMessage,
     fullScreen = false,
     avatar,
     botTypingPlaceholder,
@@ -75,6 +78,7 @@ export const Chatbot = forwardRef(function Chatbot(
           config={config}
           customChannelId={customChannelId}
           initMessages={initMessages}
+          onSseMessage={onSseMessage}
           botTypingPlaceholder={botTypingPlaceholder}
         >
           <ChatbotContainer fullScreen={fullScreen}>

--- a/packages/react/src/components/templates/button-template/card.tsx
+++ b/packages/react/src/components/templates/button-template/card.tsx
@@ -44,14 +44,23 @@ export function Card(props: CardProps): ReactNode {
           case 'message':
           case 'MESSAGE':
             sendMessage?.({ text: action.text });
+
             return;
           case 'uri':
           case 'URI':
             window.open(action.uri, action.target || '_self');
+
             return;
           case 'emit':
           case 'EMIT':
-            onTemplateBtnClick?.(action.payload);
+            onTemplateBtnClick?.(action.payload, {
+              sse: {
+                sendMessage: (payload) => {
+                  sendMessage?.(payload);
+                },
+              },
+            });
+
             return;
         }
       };

--- a/packages/react/src/context/asgard-service-context.tsx
+++ b/packages/react/src/context/asgard-service-context.tsx
@@ -16,6 +16,7 @@ import {
 import {
   useAsgardServiceClient,
   useChannel,
+  UseChannelProps,
   UseChannelReturn,
 } from 'src/hooks';
 
@@ -56,6 +57,7 @@ export interface AsgardServiceContextProviderProps {
   customMessageId?: string;
   delayTime?: number;
   initMessages?: ConversationMessage[];
+  onSseMessage?: UseChannelProps['onSseMessage'];
 }
 
 export function AsgardServiceContextProvider(
@@ -69,6 +71,7 @@ export function AsgardServiceContextProvider(
     botTypingPlaceholder,
     customChannelId,
     initMessages,
+    onSseMessage,
   } = props;
 
   const messageBoxBottomRef = useRef<HTMLDivElement>(null);
@@ -87,6 +90,7 @@ export function AsgardServiceContextProvider(
     client,
     customChannelId,
     initMessages,
+    onSseMessage,
   });
 
   const contextValue = useMemo(

--- a/packages/react/src/context/asgard-service-context.tsx
+++ b/packages/react/src/context/asgard-service-context.tsx
@@ -5,11 +5,11 @@ import {
 } from '@asgard-js/core';
 import {
   createContext,
-  DetailedHTMLProps,
-  HTMLAttributes,
+  ForwardedRef,
   ReactNode,
   RefObject,
   useContext,
+  useImperativeHandle,
   useMemo,
   useRef,
 } from 'react';
@@ -44,9 +44,11 @@ export const AsgardServiceContext = createContext<AsgardServiceContextValue>({
   botTypingPlaceholder: undefined,
 });
 
-interface AsgardServiceContextProviderProps
-  extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+export interface AsgardServiceContextProviderProps {
   children: ReactNode;
+  parentRef?: ForwardedRef<
+    Partial<{ serviceContext?: AsgardServiceContextValue }>
+  >;
   avatar?: string;
   config: ClientConfig;
   botTypingPlaceholder?: string;
@@ -62,6 +64,7 @@ export function AsgardServiceContextProvider(
   const {
     avatar,
     children,
+    parentRef,
     config,
     botTypingPlaceholder,
     customChannelId,
@@ -113,6 +116,12 @@ export function AsgardServiceContextProvider(
       botTypingPlaceholder,
     ]
   );
+
+  useImperativeHandle(parentRef, () => {
+    return {
+      serviceContext: contextValue,
+    };
+  });
 
   return (
     <AsgardServiceContext.Provider value={contextValue}>

--- a/packages/react/src/context/asgard-template-context.tsx
+++ b/packages/react/src/context/asgard-template-context.tsx
@@ -5,12 +5,23 @@ import {
   useContext,
   useMemo,
 } from 'react';
-import { ConversationErrorMessage } from '@asgard-js/core';
+import { ConversationErrorMessage, FetchSsePayload } from '@asgard-js/core';
 
 export interface AsgardTemplateContextValue {
   onErrorClick?: (message: ConversationErrorMessage) => void;
   errorMessageRenderer?: (message: ConversationErrorMessage) => ReactNode;
-  onTemplateBtnClick?: (payload: any) => void;
+  onTemplateBtnClick?: (
+    payload: Record<string, unknown>,
+    {
+      sse,
+    }: {
+      sse: {
+        sendMessage: (
+          payload: Pick<FetchSsePayload, 'text' | 'payload'>
+        ) => void;
+      };
+    }
+  ) => void;
 }
 
 export const AsgardTemplateContext = createContext<AsgardTemplateContextValue>({
@@ -22,7 +33,18 @@ export const AsgardTemplateContext = createContext<AsgardTemplateContextValue>({
 interface AsgardTemplateContextProviderProps extends PropsWithChildren {
   onErrorClick?: (message: ConversationErrorMessage) => void;
   errorMessageRenderer?: (message: ConversationErrorMessage) => ReactNode;
-  onTemplateBtnClick?: (payload: any) => void;
+  onTemplateBtnClick?: (
+    payload: Record<string, unknown>,
+    {
+      sse,
+    }: {
+      sse: {
+        sendMessage: (
+          payload: Pick<FetchSsePayload, 'text' | 'payload'>
+        ) => void;
+      };
+    }
+  ) => void;
 }
 
 export function AsgardTemplateContextProvider(

--- a/packages/react/src/hooks/use-channel.ts
+++ b/packages/react/src/hooks/use-channel.ts
@@ -4,17 +4,25 @@ import {
   ChannelStates,
   Conversation,
   ConversationMessage,
+  EventType,
   FetchSsePayload,
+  SseResponse,
 } from '@asgard-js/core';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-interface UseChannelProps {
+export interface UseChannelProps {
   defaultIsOpen?: boolean;
   resetPayload?: Pick<FetchSsePayload, 'text' | 'payload'>;
   client: AsgardServiceClient | null;
   customChannelId: string;
   customMessageId?: string;
   initMessages?: ConversationMessage[];
+  onSseMessage?: (
+    response: SseResponse<EventType>,
+    context: {
+      conversation: Conversation | null;
+    }
+  ) => void;
 }
 
 export interface UseChannelReturn {
@@ -35,6 +43,7 @@ export function useChannel(props: UseChannelProps): UseChannelReturn {
     customChannelId,
     customMessageId,
     initMessages,
+    onSseMessage,
   } = props;
 
   if (!client) {
@@ -82,13 +91,18 @@ export function useChannel(props: UseChannelProps): UseChannelReturn {
           onSseError() {
             setIsResetting(false);
           },
+          onSseMessage(response: SseResponse<EventType>) {
+            onSseMessage?.(response, {
+              conversation,
+            });
+          },
         }
       );
 
       setIsOpen(true);
       setChannel(channel);
     },
-    [client, customChannelId, customMessageId, initMessages]
+    [client, customChannelId, customMessageId, initMessages, onSseMessage]
   );
 
   const closeChannel = useCallback(() => {


### PR DESCRIPTION
re https://app.clickup.com/t/86etdh7j0

## What
* export `ref` from `Chatbot` component which provide some methods and state from `AsgardServiceContextValue`, so a user can proactively send a SSE message to server by using `chatbotRef.current?.serviceContext?.sendMessage?.({ text: 'Hello' })`
* add `onSseMessage` callback which would be triggered when a new SSE message is received, which can provide some context/conversations for users when users want to handle some customize behaviors.
* `onTemplateBtnClick` now will pass a second argument (`{ sse: { sendMessage } }`) for convenience purpose  to send a message back to server. This method is considered an internal method and not recommended to user for common scenarios, so it is not mentioned in the document.

## Preview
https://github.com/user-attachments/assets/4d988fcc-f1d6-4a26-aa1c-df2deee7da86

