### PR TITLE
fix($core): enable SSE connection when browser tab is hidden

### DIFF
--- a/packages/core/src/lib/create-sse-observable.ts
+++ b/packages/core/src/lib/create-sse-observable.ts
@@ -46,6 +46,10 @@ export function createSseObservable(
       headers,
       body: payload ? JSON.stringify(payload) : undefined,
       signal: controller.signal,
+      /**
+       * Allow SSE to work when the page is hidden.
+       * https://github.com/Azure/fetch-event-source/issues/17#issuecomment-1525904929
+       */
       openWhenHidden: true,
       onopen: async (response) => {
         if (!response.ok) {


### PR DESCRIPTION
re https://app.clickup.com/t/86et7btug
re https://github.com/Azure/fetch-event-source/issues/17#issuecomment-1525904929

## Description
Prevent SSE idling when running in the background by enabling `openWhenHidden` option

## Preview
https://drive.google.com/file/d/1NwUeW5u2_n6Kmk-qTqH-WeAUuQ-b6AGX/view?usp=sharing

