### PR TITLE
ci: enforce npm package publishing only from main branch tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   publish:
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -19,6 +18,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # for tags
+
+      - name: Ensure tag is on main branch
+        run: |
+          TAG_COMMIT=$(git rev-parse ${{ github.ref }})
+          git fetch origin main
+          if ! git merge-base --is-ancestor $TAG_COMMIT origin/main; then
+            echo "Tag is not on main branch. Skipping publish."
+            exit 0
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Description

Fix the ci is skipped issue

Merge it directly for testing. It should be safe to execute since the dry-run flag is passed.