### PR TITLE
fix: update git workflow to handle tag publishing and branch reference correctly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # for tags
+          ref: ci/NO-TICKET-fix-some-ref-failed-to-push-error
 
       - name: Ensure tag is on main branch
         run: |
@@ -25,7 +26,7 @@ jobs:
           git fetch origin main
           if ! git merge-base --is-ancestor $TAG_COMMIT origin/main; then
             echo "Tag is not on main branch. Skipping publish."
-            exit 0
+            exit 1
           fi
 
       - name: Setup Node.js
@@ -53,7 +54,7 @@ jobs:
           git commit -m "chore(release): v${{ steps.bump.outputs.new_version }}"
           git tag @asgard-js/core@${{ steps.bump.outputs.new_version }}
           git tag @asgard-js/react@${{ steps.bump.outputs.new_version }}
-          git push origin main
+          git push origin ci/NO-TICKET-fix-some-ref-failed-to-push-error
           git push origin @asgard-js/core@${{ steps.bump.outputs.new_version }}
           git push origin @asgard-js/react@${{ steps.bump.outputs.new_version }}
 


### PR DESCRIPTION
## Description
* Exit with `1` flag to avoid unexpected execution of steps
* test the ref with `ci/NO-TICKET-fix-some-ref-failed-to-push-error` first

**Note: use `ci/NO-TICKET-fix-some-ref-failed-to-push-error` branch temporarily to avoid alter `main` branch without testing**