### PR TITLE
ci: remove nx:reset command from npm install step in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
-        run: npm run nx:reset && npm install
+        run: npm install
 
       - name: Bump version (core & react)
         id: bump


### PR DESCRIPTION
## Description
* Remove `nx:reset` command before `npm install` to avoid errors