### PR TITLE
feat: upgrade to 0.0.26 to fix peer-dependency issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23452,7 +23452,7 @@
     },
     "packages/core": {
       "name": "@asgard-js/core",
-      "version": "0.0.24",
+      "version": "0.0.26",
       "dependencies": {
         "@microsoft/fetch-event-source": "^2.0.1",
         "rxjs": "^7.8.1"
@@ -23686,7 +23686,7 @@
     },
     "packages/react": {
       "name": "@asgard-js/react",
-      "version": "0.0.24",
+      "version": "0.0.26",
       "dependencies": {
         "clsx": "^2.1.1",
         "dompurify": "^3.2.5",
@@ -23710,7 +23710,7 @@
         "vitest": "^1.6.0"
       },
       "peerDependencies": {
-        "@asgard-js/core": "^0.0.24",
+        "@asgard-js/core": "^0.0.26",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asgard-js/core",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "dependencies": {
     "@microsoft/fetch-event-source": "^2.0.1",
     "rxjs": "^7.8.1"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asgard-js/react",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "publishConfig": {
     "access": "public"
   },
@@ -48,7 +48,7 @@
     "vitest": "^1.6.0"
   },
   "peerDependencies": {
-    "@asgard-js/core": "^0.0.24",
+    "@asgard-js/core": "^0.0.26",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,8 +31,8 @@
     "@csstools/css-tokenizer" "^3.0.3"
     lru-cache "^10.4.3"
 
-"@asgard-js/core@^0.0.24", "@asgard-js/core@file:/Users/chiahaolin/Documents/repos/asgard/asgard-js-sdk/packages/core":
-  version "0.0.24"
+"@asgard-js/core@^0.0.26", "@asgard-js/core@file:/Users/chiahaolin/Documents/repos/asgard/asgard-js-sdk/packages/core":
+  version "0.0.26"
   resolved "file:packages/core"
   dependencies:
     "@microsoft/fetch-event-source" "^2.0.1"
@@ -43,7 +43,7 @@
   resolved "file:apps/react-demo"
 
 "@asgard-js/react@file:/Users/chiahaolin/Documents/repos/asgard/asgard-js-sdk/packages/react":
-  version "0.0.24"
+  version "0.0.26"
   resolved "file:packages/react"
   dependencies:
     clsx "^2.1.1"


### PR DESCRIPTION
## Description
Bump a new version to v0.0.26 again to fix the peer-dependency issue from `@asgard/react`