### PR TITLE
fix: move vega to peer dependencies

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,9 +31,7 @@
     "highlight.js": "^11.11.1",
     "marked": "^15.0.8",
     "marked-highlight": "^2.2.1",
-    "react-vega": "^7.6.0",
-    "vega": "^6.1.2",
-    "vega-lite": "^6.1.0"
+    "react-vega": "^7.6.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",
@@ -50,7 +48,9 @@
   "peerDependencies": {
     "@asgard-js/core": "^0.0.26",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "vega": "^6.1.2",
+    "vega-lite": "^6.1.0"
   },
   "scripts": {
     "test": "vitest run",


### PR DESCRIPTION
dependencies 中的套件會造成嵌套依賴衝突，peerDependencies 則會扁平化安裝，避免循環。