### PR TITLE
feat: bump version to 0.0.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21835,7 +21835,7 @@
     },
     "packages/core": {
       "name": "@asgard-js/core",
-      "version": "0.0.27",
+      "version": "0.0.29",
       "dependencies": {
         "@microsoft/fetch-event-source": "^2.0.1",
         "rxjs": "^7.8.1"
@@ -22069,7 +22069,7 @@
     },
     "packages/react": {
       "name": "@asgard-js/react",
-      "version": "0.0.27",
+      "version": "0.0.29",
       "dependencies": {
         "clsx": "^2.1.1",
         "dompurify": "^3.2.5",
@@ -22091,7 +22091,7 @@
         "vitest": "^1.6.0"
       },
       "peerDependencies": {
-        "@asgard-js/core": "^0.0.27",
+        "@asgard-js/core": "^0.0.29",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "vega": "^6.1.2",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asgard-js/core",
-  "version": "0.0.19",
+  "version": "0.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asgard-js/core",
-      "version": "0.0.19",
+      "version": "0.0.29",
       "dependencies": {
         "@microsoft/fetch-event-source": "^2.0.1",
         "rxjs": "^7.8.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asgard-js/core",
-  "version": "0.0.27",
+  "version": "0.0.29",
   "dependencies": {
     "@microsoft/fetch-event-source": "^2.0.1",
     "rxjs": "^7.8.1"

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asgard-js/react",
-  "version": "0.0.19",
+  "version": "0.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asgard-js/react",
-      "version": "0.0.19",
+      "version": "0.0.29",
       "dependencies": {
         "clsx": "^2.1.1",
         "dompurify": "^3.2.5",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asgard-js/react",
-  "version": "0.0.27",
+  "version": "0.0.29",
   "publishConfig": {
     "access": "public"
   },
@@ -46,7 +46,7 @@
     "vitest": "^1.6.0"
   },
   "peerDependencies": {
-    "@asgard-js/core": "^0.0.27",
+    "@asgard-js/core": "^0.0.29",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "vega": "^6.1.2",


### PR DESCRIPTION
## Description
- Updated package.json and package-lock.json files across the monorepo to version 0.0.29.
  - Ignore 0.0.27 & 0.0.28 due to some publication issue