### PR TITLE
style: add dimming effect to markdown links with inherited color

### DIFF
--- a/packages/react/src/components/templates/text-template/text-template.module.scss
+++ b/packages/react/src/components/templates/text-template/text-template.module.scss
@@ -129,3 +129,8 @@
     transform: translateY(-5px);
   }
 }
+
+.link {
+  filter: brightness(0.8);
+  color: inherit;
+}

--- a/packages/react/src/components/templates/text-template/use-react-markdown-renderer.tsx
+++ b/packages/react/src/components/templates/text-template/use-react-markdown-renderer.tsx
@@ -15,7 +15,6 @@ import 'katex/dist/katex.min.css';
 import classes from './text-template.module.scss';
 import { useAsgardTemplateContext } from 'src/context/asgard-template-context';
 import { safeWindowOpen } from 'src/utils/uri-validation';
-
 interface MarkdownRenderResult {
   htmlBlocks: ReactNode;
   lastTypingText: string;
@@ -113,7 +112,13 @@ const LinkRenderer = ({ children, href, ...props }: any): ReactNode => {
   );
 
   return (
-    <a href={href} onClick={handleClick} rel="noopener noreferrer" {...props}>
+    <a
+      className={classes.link}
+      href={href}
+      onClick={handleClick}
+      rel="noopener noreferrer"
+      {...props}
+    >
       {children}
     </a>
   );


### PR DESCRIPTION
## Description
- Darken the color of link texts to be 80% of the normal text