### PR TITLE
fix(react): adjust textarea height to prevent layout shift on input

### DIFF
--- a/packages/react/src/components/chatbot/chatbot-footer/chatbot-footer.module.scss
+++ b/packages/react/src/components/chatbot/chatbot-footer/chatbot-footer.module.scss
@@ -15,7 +15,7 @@
 .chatbot_textarea {
   font: inherit;
   font-size: 16px;
-  height: 36px;
+  height: 40px !important;
   max-height: 240px;
   padding: 8px;
   padding-left: 12px;


### PR DESCRIPTION
chatbot footer 的輸入框，避免輸入文字後造成高度偏移

https://app.clickup.com/t/86euzkb6f