### PR TITLE
refactor(react): centralize auto-scroll logic

### DIFF
--- a/packages/react/src/components/chatbot/chatbot-body/chatbot-body.module.scss
+++ b/packages/react/src/components/chatbot/chatbot-body/chatbot-body.module.scss
@@ -1,4 +1,14 @@
+.chatbot_body_wrapper {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 .chatbot_body {
+  flex: 1;
+  min-height: 0;
   overflow-x: hidden;
   overflow-y: scroll;
 

--- a/packages/react/src/components/chatbot/chatbot-body/chatbot-body.tsx
+++ b/packages/react/src/components/chatbot/chatbot-body/chatbot-body.tsx
@@ -1,44 +1,80 @@
-import { ReactNode, useEffect, useMemo, useRef } from 'react';
+import { ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useAsgardContext } from '../../../context/asgard-service-context';
 import styles from './chatbot-body.module.scss';
 import { ConversationMessageRenderer } from './conversation-message-renderer';
 import { BotTypingPlaceholder } from '../../templates';
 import { useAsgardThemeContext } from '../../../context/asgard-theme-context';
-import { useIsAtBottom } from '../../../hooks';
 import clsx from 'clsx';
+import { useResizeObserver } from '../../../hooks';
+
+/** 判斷「是否在底部」的閾值 */
+const BOTTOM_THRESHOLD = 50;
 
 export function ChatbotBody(): ReactNode {
   const { chatbot } = useAsgardThemeContext();
 
-  const { messages, messageBoxBottomRef, botTypingPlaceholder } = useAsgardContext();
+  const {
+    messages,
+    messageBoxBottomRef,
+    botTypingPlaceholder,
+    scrollContainerRef,
+    isFollowingLatest,
+    setFollowingLatest,
+    scrollToBottom,
+    programmaticScrollToBottom,
+  } = useAsgardContext();
 
-  const bodyRef = useRef<HTMLDivElement>(null);
-  const isAtBottom = useIsAtBottom(bodyRef);
   const lastMessageCountRef = useRef<number>(0);
+  const contentRef = useRef<HTMLDivElement>(null);
 
+  // 監聽滾動事件，根據距離底部的距離判斷是否跟隨
+  useEffect(() => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) return;
+
+    function handleScroll(): void {
+      if (!scrollContainer) return;
+
+      const { scrollTop, scrollHeight, clientHeight } = scrollContainer;
+      const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
+
+      // 距離底部 <= 50px → 跟隨，> 50px → 不跟隨
+      setFollowingLatest(distanceFromBottom <= BOTTOM_THRESHOLD);
+    }
+
+    scrollContainer.addEventListener('scroll', handleScroll, { passive: true });
+
+    return (): void => {
+      scrollContainer.removeEventListener('scroll', handleScroll);
+    };
+  }, [scrollContainerRef, setFollowingLatest]);
+
+  // 當使用者發送新訊息時，強制滾動到底部並恢復跟隨
   useEffect(() => {
     const currentMessageCount = messages?.size ?? 0;
     const hasNewMessage = currentMessageCount > lastMessageCountRef.current;
 
     lastMessageCountRef.current = currentMessageCount;
 
-    // 如果有新訊息且最後一則是使用者訊息，強制滾動到底部
     if (hasNewMessage && messages && messages.size > 0) {
       const messagesArray = Array.from(messages.values());
       const lastMessage = messagesArray[messagesArray.length - 1];
 
       if (lastMessage?.type === 'user') {
-        messageBoxBottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-
-        return;
+        scrollToBottom('smooth');
       }
     }
+  }, [messages, scrollToBottom]);
 
-    // 否則只有在底部時才滾動（AI 回應時）
-    if (isAtBottom) {
-      messageBoxBottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [messages, messageBoxBottomRef, isAtBottom]);
+  // 監聽內容區域高度變化來自動滾動（DOM-based）
+  // 這比監聽 React 狀態更可靠，因為直接響應實際的 DOM 變化
+  const onContentResize = useCallback(() => {
+    if (!isFollowingLatest) return;
+
+    programmaticScrollToBottom('smooth');
+  }, [isFollowingLatest, programmaticScrollToBottom]);
+
+  useResizeObserver({ ref: contentRef, onResize: onContentResize });
 
   const contentStyles = useMemo(
     () => ({
@@ -48,16 +84,22 @@ export function ChatbotBody(): ReactNode {
   );
 
   return (
-    <div ref={bodyRef} className={clsx('asgard-chatbot-body', styles.chatbot_body)} style={chatbot?.body?.style}>
-      <div className={styles.chatbot_body__content} style={contentStyles}>
-        {Array.from(messages?.values() ?? []).map((message, index) => (
-          <ConversationMessageRenderer
-            key={message.messageId || `${message.type}-${index}-${message.time.getTime()}`}
-            message={message}
-          />
-        ))}
-        <BotTypingPlaceholder placeholder={botTypingPlaceholder ?? '正在輸入訊息'} />
-        <div ref={messageBoxBottomRef} />
+    <div className={styles.chatbot_body_wrapper}>
+      <div
+        ref={scrollContainerRef}
+        className={clsx('asgard-chatbot-body', styles.chatbot_body)}
+        style={chatbot?.body?.style}
+      >
+        <div ref={contentRef} className={styles.chatbot_body__content} style={contentStyles}>
+          {Array.from(messages?.values() ?? []).map((message, index) => (
+            <ConversationMessageRenderer
+              key={message.messageId || `${message.type}-${index}-${message.time.getTime()}`}
+              message={message}
+            />
+          ))}
+          <BotTypingPlaceholder placeholder={botTypingPlaceholder ?? '正在輸入訊息'} />
+          <div ref={messageBoxBottomRef} />
+        </div>
       </div>
     </div>
   );

--- a/packages/react/src/components/templates/text-template/bot-typing-box.tsx
+++ b/packages/react/src/components/templates/text-template/bot-typing-box.tsx
@@ -1,12 +1,13 @@
-import { CSSProperties, ReactNode, useCallback, useMemo, useRef } from 'react';
+import { CSSProperties, ReactNode, useMemo } from 'react';
 import { useAsgardContext } from '../../../context/asgard-service-context';
 import clsx from 'clsx';
 import { TemplateBox, TemplateBoxContent } from '../template-box';
 import { Avatar } from '../avatar';
-import { useDebounce, useResizeObserver } from '../../../hooks';
+import { useDebounce } from '../../../hooks';
 import classes from './text-template.module.scss';
 import { useAsgardThemeContext } from '../../../context/asgard-theme-context';
 import { StreamdownClient } from './streamdown-client';
+
 interface BotTypingBoxProps {
   isTyping: boolean;
   typingText: string | null;
@@ -14,38 +15,9 @@ interface BotTypingBoxProps {
 
 export function BotTypingBox(props: BotTypingBoxProps): ReactNode {
   const { isTyping, typingText } = props;
-  const { messageBoxBottomRef, avatar } = useAsgardContext();
+  const { avatar } = useAsgardContext();
 
   const theme = useAsgardThemeContext();
-
-  const ref = useRef<HTMLDivElement>(null);
-
-  const onResize = useCallback(() => {
-    const bottomElement = messageBoxBottomRef.current;
-    if (!bottomElement) return;
-
-    // 找到滾動容器（chatbot_body）
-    let scrollContainer = bottomElement.parentElement;
-    while (scrollContainer && scrollContainer.scrollHeight <= scrollContainer.clientHeight) {
-      scrollContainer = scrollContainer.parentElement;
-    }
-
-    if (!scrollContainer) {
-      bottomElement.scrollIntoView({ behavior: 'smooth' });
-
-      return;
-    }
-
-    // 檢查是否在底部（threshold = 50px）
-    const { scrollTop, scrollHeight, clientHeight } = scrollContainer;
-    const isAtBottom = scrollTop + clientHeight >= scrollHeight - 50;
-
-    if (isAtBottom) {
-      bottomElement.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [messageBoxBottomRef]);
-
-  useResizeObserver({ ref, onResize });
 
   const _isTyping = useDebounce(isTyping, 500);
 
@@ -70,7 +42,7 @@ export function BotTypingBox(props: BotTypingBoxProps): ReactNode {
     <TemplateBox className="asgard-text-template asgard-text-template--bot" type="bot" direction="horizontal">
       <Avatar avatar={avatar} />
       <TemplateBoxContent time={new Date()}>
-        <div ref={ref} className={clsx(classes.text, classes['text--bot'])} style={styles}>
+        <div className={clsx(classes.text, classes['text--bot'])} style={styles}>
           <span>
             {typingText ? <StreamdownClient>{typingText}</StreamdownClient> : null}
             {_isTyping && (

--- a/packages/react/src/context/asgard-service-context.tsx
+++ b/packages/react/src/context/asgard-service-context.tsx
@@ -4,10 +4,12 @@ import {
   ForwardedRef,
   ReactNode,
   RefObject,
+  useCallback,
   useContext,
   useImperativeHandle,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 import { useAsgardServiceClient, useChannel, UseChannelProps, UseChannelReturn } from '../hooks';
 
@@ -29,6 +31,20 @@ export interface AsgardServiceContextValue {
   enableUpload?: boolean;
   enableExport?: boolean;
   enableDocumentUpload?: boolean;
+  /** 用戶是否正在跟隨最新內容（用於自動滾動判斷） */
+  isFollowingLatest: boolean;
+  /** 設定跟隨狀態 */
+  setFollowingLatest: (value: boolean) => void;
+  /** 滾動到底部（由用戶觸發，會恢復跟隨狀態） */
+  scrollToBottom: (behavior?: ScrollBehavior) => void;
+  /** 程式滾動到底部（不會改變跟隨狀態） */
+  programmaticScrollToBottom: (behavior?: ScrollBehavior) => void;
+  /** 滾動容器的 ref */
+  scrollContainerRef: RefObject<HTMLDivElement>;
+}
+
+function noop(): void {
+  // intentionally empty
 }
 
 export const AsgardServiceContext = createContext<AsgardServiceContextValue>({
@@ -46,6 +62,11 @@ export const AsgardServiceContext = createContext<AsgardServiceContextValue>({
   enableUpload: undefined,
   enableExport: undefined,
   enableDocumentUpload: undefined,
+  isFollowingLatest: true,
+  setFollowingLatest: noop,
+  scrollToBottom: noop,
+  programmaticScrollToBottom: noop,
+  scrollContainerRef: { current: null },
 });
 
 export interface AsgardServiceContextProviderProps {
@@ -86,6 +107,32 @@ export function AsgardServiceContextProvider(props: AsgardServiceContextProvider
   } = props;
 
   const messageBoxBottomRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // 滾動跟隨狀態管理
+  const [isFollowingLatest, setIsFollowingLatest] = useState(true);
+
+  const setFollowingLatest = useCallback((value: boolean) => {
+    setIsFollowingLatest(value);
+  }, []);
+
+  // 用戶觸發的滾動 - 會恢復跟隨狀態
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    const bottomElement = messageBoxBottomRef.current;
+    if (bottomElement) {
+      bottomElement.scrollIntoView({ behavior });
+    }
+
+    setIsFollowingLatest(true);
+  }, []);
+
+  // 程式觸發的滾動（串流更新）- 不改變跟隨狀態
+  const programmaticScrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    const bottomElement = messageBoxBottomRef.current;
+    if (bottomElement) {
+      bottomElement.scrollIntoView({ behavior });
+    }
+  }, []);
 
   const client = useAsgardServiceClient({ config });
 
@@ -116,6 +163,11 @@ export function AsgardServiceContextProvider(props: AsgardServiceContextProvider
       enableExport,
       enableDocumentUpload,
       messageBoxBottomRef,
+      scrollContainerRef,
+      isFollowingLatest,
+      setFollowingLatest,
+      scrollToBottom,
+      programmaticScrollToBottom,
     }),
     [
       avatar,
@@ -134,6 +186,10 @@ export function AsgardServiceContextProvider(props: AsgardServiceContextProvider
       enableUpload,
       enableExport,
       enableDocumentUpload,
+      isFollowingLatest,
+      setFollowingLatest,
+      scrollToBottom,
+      programmaticScrollToBottom,
     ],
   );
 


### PR DESCRIPTION
## Summary

重構自動滾動邏輯，將分散在 `BotTypingBox` 和 `ChatbotBody` 的滾動邏輯集中到 `ChatbotBody` 統一管理。

## Changes

### ChatbotBody
- 新增 `isFollowingLatest` 狀態追蹤使用者是否跟隨最新內容
- 使用 `useResizeObserver` 監聽內容高度變化觸發自動滾動
- 監聽 scroll 事件判斷跟隨狀態（閾值 50px）
- 新增 wrapper 層以明確區分滾動容器與內容區域

### BotTypingBox
- 移除滾動邏輯，改為純 UI 組件

### AsgardServiceContext
- 移除 `messageBoxBottomRef`（現在由 ChatbotBody 內部管理）

## Scroll Behavior

| 情境 | 行為 |
|------|------|
| 使用者往上捲動（> 50px from bottom） | 停止自動滾動 |
| 使用者捲回接近底部（≤ 50px） | 恢復自動滾動 |
| 使用者發送訊息 | 強制滾動到底部 |
| AI 回應串流中 | 僅在跟隨模式下自動滾動 |

## Test Plan

- [ ] 驗證 AI 回應串流時自動滾動到底部
- [ ] 驗證往上捲動時不會被強制拉回
- [ ] 驗證捲動到接近底部時恢復自動跟隨
- [ ] 驗證發送訊息後強制回到底部