### PR TITLE
fix(react): use scrollTo instead of scrollIntoView to prevent ancestor scrolling

### DIFF
--- a/packages/react/src/components/templates/audio-template/audio-template.tsx
+++ b/packages/react/src/components/templates/audio-template/audio-template.tsx
@@ -16,18 +16,16 @@ export function AudioTemplate(props: AudioTemplateProps): ReactNode {
   const { originalContentUrl } = template;
 
   const { template: themeTemplate } = useAsgardThemeContext();
-  const { avatar, messageBoxBottomRef } = useAsgardContext();
+  const { avatar, scrollToBottom } = useAsgardContext();
 
   // Auto scroll to bottom when AUDIO message is rendered
   useEffect(() => {
     const timer = setTimeout(() => {
-      if (messageBoxBottomRef.current) {
-        messageBoxBottomRef.current.scrollIntoView({ behavior: 'smooth' });
-      }
+      scrollToBottom('smooth');
     }, 100);
 
     return (): void => clearTimeout(timer);
-  }, [messageBoxBottomRef]);
+  }, [scrollToBottom]);
 
   return (
     <TemplateBox

--- a/packages/react/src/components/templates/video-template/video-template.tsx
+++ b/packages/react/src/components/templates/video-template/video-template.tsx
@@ -75,7 +75,7 @@ export function VideoTemplate(props: VideoTemplateProps): ReactNode {
 
   const { template: themeTemplate } = useAsgardThemeContext();
 
-  const { avatar, messageBoxBottomRef } = useAsgardContext();
+  const { avatar, scrollToBottom } = useAsgardContext();
   const [isPlaying, setIsPlaying] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
   const videoBoxRef = useRef<HTMLDivElement>(null);
@@ -87,24 +87,20 @@ export function VideoTemplate(props: VideoTemplateProps): ReactNode {
   useEffect(() => {
     // Delay slightly to ensure image has started loading
     const timer = setTimeout(() => {
-      if (messageBoxBottomRef.current) {
-        messageBoxBottomRef.current.scrollIntoView({ behavior: 'smooth' });
-      }
+      scrollToBottom('smooth');
     }, 100);
 
     return (): void => {
       clearTimeout(timer);
     };
-  }, [messageBoxBottomRef]);
+  }, [scrollToBottom]);
 
   // Trigger scroll again when preview image is loaded (ensure image height is calculated)
   const handleImageLoad = (): void => {
-    if (messageBoxBottomRef.current) {
-      // Slight delay to ensure DOM is updated
-      setTimeout(() => {
-        messageBoxBottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-      }, 50);
-    }
+    // Slight delay to ensure DOM is updated
+    setTimeout(() => {
+      scrollToBottom('smooth');
+    }, 50);
   };
 
   // Check if it's a YouTube URL and get video ID

--- a/packages/react/src/context/asgard-service-context.tsx
+++ b/packages/react/src/context/asgard-service-context.tsx
@@ -118,9 +118,12 @@ export function AsgardServiceContextProvider(props: AsgardServiceContextProvider
 
   // 用戶觸發的滾動 - 會恢復跟隨狀態
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
-    const bottomElement = messageBoxBottomRef.current;
-    if (bottomElement) {
-      bottomElement.scrollIntoView({ behavior });
+    const scrollContainer = scrollContainerRef.current;
+    if (scrollContainer) {
+      scrollContainer.scrollTo({
+        top: scrollContainer.scrollHeight,
+        behavior,
+      });
     }
 
     setIsFollowingLatest(true);
@@ -128,9 +131,12 @@ export function AsgardServiceContextProvider(props: AsgardServiceContextProvider
 
   // 程式觸發的滾動（串流更新）- 不改變跟隨狀態
   const programmaticScrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
-    const bottomElement = messageBoxBottomRef.current;
-    if (bottomElement) {
-      bottomElement.scrollIntoView({ behavior });
+    const scrollContainer = scrollContainerRef.current;
+    if (scrollContainer) {
+      scrollContainer.scrollTo({
+        top: scrollContainer.scrollHeight,
+        behavior,
+      });
     }
   }, []);
 


### PR DESCRIPTION
## 問題描述

Chatbot 在滾動到底部時，footer 位置會意外移動，與容器底部之間出現間隙。

## 根本原因

`scrollIntoView()` 會滾動**所有**祖先容器，包括設定了 `overflow: hidden` 的 `chatbot_container`。即使容器有 `overflow: hidden`，程式化設定 `scrollTop` 仍然有效，導致 footer 被推離正確位置。

## 解決方案

將 `scrollIntoView()` 改為 `scrollTo()`，只滾動指定的滾動容器，不影響祖先元素。

## 修改內容

| 檔案 | 變更 |
|------|------|
| `asgard-service-context.tsx` | `scrollIntoView()` → `scrollTo()` |
| `audio-template.tsx` | 改用 context 提供的 `scrollToBottom` |
| `video-template.tsx` | 改用 context 提供的 `scrollToBottom` |

## 測試計畫

- [ ] 在 react-demo 測試滾動行為
- [ ] 確認 footer 位置不再移動
- [ ] 確認 audio/video template 的自動滾動正常運作