### PR TITLE
fix(react): scroll chatbot container directly instead of using scrollIntoView

### DIFF
--- a/packages/react/src/context/asgard-service-context.tsx
+++ b/packages/react/src/context/asgard-service-context.tsx
@@ -146,23 +146,32 @@ export function AsgardServiceContextProvider(props: AsgardServiceContextProvider
     setIsFollowingLatest(value);
   }, []);
 
-  // 用戶觸發的滾動 - 會恢復跟隨狀態
-  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
-    const bottomElement = messageBoxBottomRef.current;
-    if (bottomElement) {
-      bottomElement.scrollIntoView({ behavior });
-    }
+  // 直接操作 chatbot 內部的 scroll container，避免使用 scrollIntoView —
+  // scrollIntoView 會冒泡到最近的可捲動祖先，當 chatbot 被嵌入到外部文件
+  // 頁面時會連帶捲動整個 <body>，把訪客推離原本的位置。
+  const scrollContainerToBottom = useCallback((behavior: ScrollBehavior) => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
 
-    setIsFollowingLatest(true);
+    container.scrollTo({ top: container.scrollHeight, behavior });
   }, []);
+
+  // 用戶觸發的滾動 - 會恢復跟隨狀態
+  const scrollToBottom = useCallback(
+    (behavior: ScrollBehavior = 'smooth') => {
+      scrollContainerToBottom(behavior);
+      setIsFollowingLatest(true);
+    },
+    [scrollContainerToBottom],
+  );
 
   // 程式觸發的滾動（串流更新）- 不改變跟隨狀態
-  const programmaticScrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
-    const bottomElement = messageBoxBottomRef.current;
-    if (bottomElement) {
-      bottomElement.scrollIntoView({ behavior });
-    }
-  }, []);
+  const programmaticScrollToBottom = useCallback(
+    (behavior: ScrollBehavior = 'smooth') => {
+      scrollContainerToBottom(behavior);
+    },
+    [scrollContainerToBottom],
+  );
 
   const client = useAsgardServiceClient({ config });
 


### PR DESCRIPTION
## Summary
- 將 `scrollToBottom` 與 `programmaticScrollToBottom` 從 `messageBoxBottomRef.current.scrollIntoView()` 改成直接呼叫 `scrollContainerRef.current.scrollTo({ top: scrollHeight })`
- 修正將 `@asgard-js/react` 嵌入到外部文件頁面（例如 docs 站）時，chatbot 掛載或訊息更新時會連帶捲動整個宿主頁面的 `<body>`，把訪客拉離原本閱讀位置的問題
- `scrollIntoView` 會沿 DOM 往上找最近的可捲動祖先，嵌入情境下會冒泡到外層頁面；改用 `scrollTo` 直接操作 chatbot 內部 container，捲動效果只會留在 chatbot 內

## Context
在建置 [`asgard-sdk-demo`](https://github.com/asgard-ai-platform/asgard-sdk-demo) 時發現，每個 demo 頁面嵌入一個 `<Chatbot />` Live 元件後，直接輸入 URL 或從 sidebar 切換頁面時，整個頁面會自動滾動到 chatbot 的位置，導致使用者看不到頁面標題與說明文字。追到根本原因是 chatbot 在掛載時帶 `initMessages` 會觸發 `programmaticScrollToBottom('smooth')`，而 `scrollIntoView` 會把宿主文件一併捲動。

## Test plan
- [ ] `npm run build:react` 通過
- [ ] react-demo 中正常串流新訊息時，chatbot 仍會跟隨到最新訊息
- [ ] react-demo 中使用者主動發送訊息後，chatbot 會捲動到底部並恢復跟隨狀態
- [ ] 將 chatbot 嵌入外部可捲動頁面（例如 `asgard-sdk-demo` 的 MDX 頁面）時，宿主頁面的捲動位置不會被改變
- [ ] `renderMenu` 點選項目後透過 ref 填入輸入框的流程不受影響