### PR TITLE
feat(react): add renderToolCallGroup prop

### DIFF
--- a/apps/react-demo/src/app/app.tsx
+++ b/apps/react-demo/src/app/app.tsx
@@ -16,6 +16,7 @@ import { CustomHeaderDemo } from './routes/custom-header';
 import { AutoResetChannel } from './routes/auto-reset-channel';
 import { RenderMenu } from './routes/render-menu';
 import { HttpErrorDemo } from './routes/http-error';
+import { ToolCallDemo } from './routes/tool-call';
 
 export function App(): React.ReactElement {
   return (
@@ -37,6 +38,7 @@ export function App(): React.ReactElement {
         <Route path="/auto-reset-channel" element={<AutoResetChannel />} />
         <Route path="/render-menu" element={<RenderMenu />} />
         <Route path="/http-error" element={<HttpErrorDemo />} />
+        <Route path="/tool-call" element={<ToolCallDemo />} />
       </Routes>
     </Layout>
   );

--- a/apps/react-demo/src/app/components/layout/layout.tsx
+++ b/apps/react-demo/src/app/components/layout/layout.tsx
@@ -22,6 +22,7 @@ const navItems = [
   { to: '/auto-reset-channel', label: 'Auto Reset Channel' },
   { to: '/render-menu', label: 'Render Menu' },
   { to: '/http-error', label: 'HTTP Error' },
+  { to: '/tool-call', label: 'Tool Call' },
 ];
 
 export function Layout({ children }: LayoutProps): ReactNode {

--- a/apps/react-demo/src/app/mocks/messages.ts
+++ b/apps/react-demo/src/app/mocks/messages.ts
@@ -1,4 +1,11 @@
-import { ConversationMessage, EventType, Message, MessageTemplateType, TableMessageTemplate } from '@asgard-js/core';
+import {
+  ConversationMessage,
+  ConversationToolCallMessage,
+  EventType,
+  Message,
+  MessageTemplateType,
+  TableMessageTemplate,
+} from '@asgard-js/core';
 import { nanoid } from 'nanoid';
 
 const quickReplies = [
@@ -668,6 +675,187 @@ export function createUserMessageExample(text: string): ConversationMessage {
     text,
     time: new Date(),
   };
+}
+
+export function createToolCallMessages(): ConversationMessage[] {
+  const processId = 'proc-001';
+  const toolCalls: ConversationToolCallMessage[] = [
+    {
+      type: 'tool-call',
+      messageId: `${processId}-0`,
+      eventType: EventType.TOOL_CALL_COMPLETE,
+      processId,
+      callSeq: 0,
+      toolName: 'validate_query',
+      toolsetName: 'data-insight',
+      parameter: { query: 'SELECT COUNT(*) FROM users GROUP BY cohort' },
+      result: { valid: true, estimatedRows: 5 },
+      isComplete: true,
+      time: new Date(),
+    },
+    {
+      type: 'tool-call',
+      messageId: `${processId}-1`,
+      eventType: EventType.TOOL_CALL_COMPLETE,
+      processId,
+      callSeq: 1,
+      toolName: 'execute_query',
+      toolsetName: 'data-insight',
+      parameter: { query: 'SELECT COUNT(*) FROM users GROUP BY cohort' },
+      result: { rowCount: 5, status: 'ok' },
+      isComplete: true,
+      time: new Date(),
+    },
+    {
+      type: 'tool-call',
+      messageId: `${processId}-2`,
+      eventType: EventType.TOOL_CALL_COMPLETE,
+      processId,
+      callSeq: 2,
+      toolName: 'render_chart',
+      toolsetName: 'data-insight',
+      parameter: { chartType: 'bar', title: '各群組新增數量' },
+      result: { viewId: 'view-123', status: 'ok' },
+      isComplete: true,
+      time: new Date(),
+    },
+  ];
+
+  return [
+    createUserMessageExample('幫我比較各群組的新增數量'),
+    ...toolCalls,
+    createBaseTemplateExample({
+      messageId: nanoid(),
+      replyToCustomMessageId: '',
+      text: '已為您產出長條圖，可以看到各群組的新增數量比較。',
+      payload: null,
+      isDebug: false,
+      idx: 0,
+      template: {
+        type: MessageTemplateType.TEXT,
+        text: '',
+        quickReplies: [{ text: '匯出報表' }, { text: '換成圓餅圖' }],
+      },
+    }),
+  ];
+}
+
+export function createPendingToolCallMessages(): ConversationMessage[] {
+  const processId = 'proc-002';
+  const toolCalls: ConversationToolCallMessage[] = [
+    {
+      type: 'tool-call',
+      messageId: `${processId}-0`,
+      eventType: EventType.TOOL_CALL_COMPLETE,
+      processId,
+      callSeq: 0,
+      toolName: 'search_weather',
+      toolsetName: 'weather-service',
+      parameter: { location: '台北', date: 'tomorrow' },
+      result: { temperature: 22, condition: 'sunny' },
+      isComplete: true,
+      time: new Date(),
+    },
+    {
+      type: 'tool-call',
+      messageId: `${processId}-1`,
+      eventType: EventType.TOOL_CALL_COMPLETE,
+      processId,
+      callSeq: 1,
+      toolName: 'search_nearby_places',
+      toolsetName: 'location-service',
+      parameter: { city: '台北', category: 'outdoor' },
+      result: { places: ['陽明山', '大稻埕', '河濱公園'] },
+      isComplete: true,
+      time: new Date(),
+    },
+    {
+      type: 'tool-call',
+      messageId: `${processId}-2`,
+      eventType: EventType.TOOL_CALL_START,
+      processId,
+      callSeq: 2,
+      toolName: 'recommend_activities',
+      toolsetName: 'activity-service',
+      parameter: { weather: 'sunny', places: ['陽明山', '大稻埕', '河濱公園'] },
+      isComplete: false,
+      time: new Date(),
+    },
+  ];
+
+  return [createUserMessageExample('幫我查台北明天天氣，並推薦適合的活動'), ...toolCalls];
+}
+
+export function createErrorToolCallMessages(): ConversationMessage[] {
+  const processId = 'proc-003';
+  const toolCalls: ConversationToolCallMessage[] = [
+    {
+      type: 'tool-call',
+      messageId: `${processId}-0`,
+      eventType: EventType.TOOL_CALL_COMPLETE,
+      processId,
+      callSeq: 0,
+      toolName: 'validate_query',
+      toolsetName: 'data-insight',
+      parameter: { query: 'SELECT * FROM orders WHERE date > now()' },
+      result: { valid: true },
+      isComplete: true,
+      time: new Date(),
+    },
+    {
+      type: 'tool-call',
+      messageId: `${processId}-1`,
+      eventType: EventType.TOOL_CALL_COMPLETE,
+      processId,
+      callSeq: 1,
+      toolName: 'check_permissions',
+      toolsetName: 'data-insight',
+      parameter: { table: 'orders', action: 'read' },
+      result: { allowed: false, reason: 'restricted table' },
+      isComplete: true,
+      time: new Date(),
+    },
+    {
+      type: 'tool-call',
+      messageId: `${processId}-2`,
+      eventType: EventType.TOOL_CALL_COMPLETE,
+      processId,
+      callSeq: 2,
+      toolName: 'execute_query',
+      toolsetName: 'data-insight',
+      parameter: { query: 'SELECT * FROM orders WHERE date > now()' },
+      result: { error: 'Permission denied: table "orders" is restricted' },
+      isComplete: true,
+      time: new Date(),
+    },
+  ];
+
+  return [
+    createUserMessageExample('幫我查詢最近的訂單資料'),
+    ...toolCalls,
+    {
+      type: 'bot',
+      messageId: nanoid(),
+      isTyping: false,
+      typingText: '',
+      eventType: EventType.MESSAGE_COMPLETE,
+      time: new Date(),
+      message: {
+        messageId: nanoid(),
+        replyToCustomMessageId: '',
+        text: '抱歉，查詢訂單資料時發生錯誤，您可能沒有該資料表的存取權限。',
+        payload: null,
+        isDebug: false,
+        idx: 0,
+        template: {
+          type: MessageTemplateType.TEXT,
+          text: '',
+          quickReplies: [],
+        },
+      },
+      raw: '',
+    },
+  ];
 }
 
 export function createMixedCustomRendererMessages(): ConversationMessage[] {

--- a/apps/react-demo/src/app/routes/home/home.tsx
+++ b/apps/react-demo/src/app/routes/home/home.tsx
@@ -98,22 +98,27 @@ import '@asgard-js/react/style';
       </footer>
 
       {isOpen && (
-        <div className={styles.chatbotContainer}>
+        <div
+          style={{
+            position: 'fixed',
+            bottom: '100px',
+            right: '24px',
+            zIndex: 1000,
+          }}
+        >
           <Chatbot
-            title="Asgard Chatbot"
+            // title="Asgard Chatbot"
             config={{
               botProviderEndpoint: import.meta.env.VITE_SIMPLE_BOT_PROVIDER_ENDPOINT,
             }}
             customChannelId="home-demo"
             theme={{
               chatbot: {
-                width: '380px',
+                width: '480px',
                 height: '550px',
                 borderRadius: '16px',
               },
             }}
-            enableUpload
-            enableDocumentUpload
             onSseMessage={handleSseMessage}
             onClose={() => setIsOpen(false)}
           />

--- a/apps/react-demo/src/app/routes/tool-call/index.ts
+++ b/apps/react-demo/src/app/routes/tool-call/index.ts
@@ -1,0 +1,1 @@
+export { ToolCallDemo } from './tool-call';

--- a/apps/react-demo/src/app/routes/tool-call/tool-call.module.scss
+++ b/apps/react-demo/src/app/routes/tool-call/tool-call.module.scss
@@ -1,0 +1,256 @@
+.controls {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  width: 400px;
+  flex-shrink: 0;
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
+
+  h3 {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1a1a2e;
+    margin: 0 0 16px 0;
+  }
+
+  h4 {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1a1a2e;
+    margin: 0 0 12px 0;
+  }
+}
+
+.scenarioList {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.scenarioButton {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: white;
+  color: #666;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    border-color: #4a9eff;
+    color: #4a9eff;
+  }
+
+  &.active {
+    border-color: #4a9eff;
+    background: #4a9eff;
+    color: white;
+  }
+}
+
+.modeList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.modeButton {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 12px 16px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: white;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.2s ease;
+
+  &:hover {
+    border-color: #4a9eff;
+    background: #f8faff;
+  }
+
+  &.active {
+    border-color: #4a9eff;
+    background: #4a9eff;
+
+    .modeLabel {
+      color: white;
+    }
+
+    .modeDescription {
+      color: rgba(255, 255, 255, 0.8);
+    }
+  }
+}
+
+.modeLabel {
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 4px;
+}
+
+.modeDescription {
+  font-size: 12px;
+  color: #666;
+}
+
+.codePreview {
+  background: #f5f5f5;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.code {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: #333;
+}
+
+.chatbotContainer {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+
+  > div {
+    width: 100%;
+    max-width: 420px;
+    height: 600px;
+  }
+}
+
+// Summary renderer
+.summaryBox {
+  padding: 8px 12px;
+  margin: 8px 0;
+  border-radius: 8px;
+  background: var(--asg-color-secondary, #2a2a3a);
+  font-size: 13px;
+  color: var(--asg-color-text, #e0e0e0);
+}
+
+// Step card renderer
+.customCard {
+  margin: 8px 0;
+  border-radius: 10px;
+  border: 1px solid var(--asg-color-border, rgba(255, 255, 255, 0.12));
+  overflow: hidden;
+  font-size: 13px;
+}
+
+.customCardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 10px 14px;
+  border: none;
+  background: var(--asg-color-secondary, #2a2a3a);
+  color: var(--asg-color-text, #e0e0e0);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  transition: background 0.15s;
+
+  &:hover {
+    filter: brightness(1.1);
+  }
+}
+
+.customCardTitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.customCardIndicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+
+  &.done {
+    background: #52c41a;
+  }
+
+  &.running {
+    background: #1890ff;
+    animation: pulse 1.2s ease-in-out infinite;
+  }
+
+  &.error {
+    background: #ff4d4f;
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.customCardChevron {
+  transition: transform 0.2s;
+  font-size: 11px;
+  opacity: 0.6;
+
+  &.expanded {
+    transform: rotate(180deg);
+  }
+}
+
+.customCardBody {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  background: var(--asg-color-border, rgba(255, 255, 255, 0.06));
+}
+
+.customCardStep {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: var(--asg-color-secondary, #2a2a3a);
+}
+
+.customCardStepIcon {
+  font-size: 14px;
+  font-weight: 700;
+  width: 18px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.customCardStepName {
+  flex: 1;
+  color: var(--asg-color-text, #e0e0e0);
+  font-family: monospace;
+  font-size: 12px;
+}
+
+.customCardStepBadge {
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  flex-shrink: 0;
+}

--- a/apps/react-demo/src/app/routes/tool-call/tool-call.tsx
+++ b/apps/react-demo/src/app/routes/tool-call/tool-call.tsx
@@ -1,0 +1,261 @@
+import { ReactNode, useState } from 'react';
+import { Chatbot, ToolCallItemData, ToolCallStatus } from '@asgard-js/react';
+import '@asgard-js/react/style';
+import { DemoWrapper } from '../../components/demo-wrapper';
+import {
+  createToolCallMessages,
+  createPendingToolCallMessages,
+  createErrorToolCallMessages,
+} from '../../mocks/messages';
+import styles from './tool-call.module.scss';
+
+type Scenario = 'completed' | 'pending' | 'error';
+
+const scenarioOptions: { value: Scenario; label: string; description: string }[] = [
+  { value: 'completed', label: 'Completed', description: 'All tool calls finished successfully' },
+  { value: 'pending', label: 'Pending', description: 'One tool call still in progress' },
+  { value: 'error', label: 'Error', description: 'A tool call failed with an error' },
+];
+
+const scenarioMessages: Record<Scenario, () => ReturnType<typeof createToolCallMessages>> = {
+  completed: createToolCallMessages,
+  pending: createPendingToolCallMessages,
+  error: createErrorToolCallMessages,
+};
+
+type RenderMode = 'default' | 'hidden' | 'custom-title' | 'summary' | 'steps';
+
+const modeOptions: { value: RenderMode; label: string; description: string }[] = [
+  {
+    value: 'default',
+    label: 'Default',
+    description: 'Built-in "Answer preparation steps" UI with expandable tool details',
+  },
+  {
+    value: 'hidden',
+    label: 'Hidden',
+    description: 'Completely hide the tool call group from end users',
+  },
+  {
+    value: 'custom-title',
+    label: 'Custom Title',
+    description: 'Keep the default UI but change the title text',
+  },
+  {
+    value: 'summary',
+    label: 'Summary',
+    description: 'Replace with a one-line status summary',
+  },
+  {
+    value: 'steps',
+    label: 'Step Card',
+    description: 'Custom expandable card showing each tool name and status badge',
+  },
+];
+
+const codeExamples: Record<RenderMode, string> = {
+  default: `// No prop needed — uses built-in UI
+<Chatbot
+  config={{ botProviderEndpoint: '...' }}
+  customChannelId="my-channel"
+/>`,
+  hidden: `// Return null to hide completely
+<Chatbot
+  renderToolCallGroup={() => null}
+  ...
+/>`,
+  'custom-title': `// Override title only, keep default UI
+<Chatbot
+  renderToolCallGroup={({ renderDefaultContent }) =>
+    renderDefaultContent({ title: 'AI is thinking...' })
+  }
+  ...
+/>`,
+  summary: `// Custom one-line summary
+<Chatbot
+  renderToolCallGroup={({ items }) => {
+    const done = items.filter(i => i.status === 'completed').length;
+    return (
+      <div>
+        {done === items.length
+          ? \`✅ \${done} step(s) completed\`
+          : \`⏳ Processing...\`}
+      </div>
+    );
+  }}
+  ...
+/>`,
+  steps: `// Custom expandable step card
+<Chatbot
+  renderToolCallGroup={({ items }) => {
+    return (
+      <StepCard items={items} />
+      // Each item has: id, label, status,
+      // initial (parameters), result
+    );
+  }}
+  ...
+/>`,
+};
+
+const statusConfig: Record<ToolCallStatus, { icon: string; color: string; label: string }> = {
+  completed: { icon: '✓', color: '#52c41a', label: 'Done' },
+  pending: { icon: '⟳', color: '#1890ff', label: 'Running' },
+  error: { icon: '✗', color: '#ff4d4f', label: 'Failed' },
+};
+
+function SummaryRenderer({ items }: { items: ToolCallItemData[] }): ReactNode {
+  const completed = items.filter(i => i.status === 'completed').length;
+  const pending = items.filter(i => i.status === 'pending').length;
+  const error = items.filter(i => i.status === 'error').length;
+
+  return (
+    <div className={styles.summaryBox}>
+      {pending > 0 ? `⏳ ${pending} step(s) in progress...` : `✅ ${completed} step(s) completed`}
+      {error > 0 && ` · ❌ ${error} failed`}
+    </div>
+  );
+}
+
+function StepCardRenderer({ items }: { items: ToolCallItemData[] }): ReactNode {
+  const [expanded, setExpanded] = useState(false);
+  const completed = items.filter(i => i.status === 'completed').length;
+  const pending = items.filter(i => i.status === 'pending').length;
+  const error = items.filter(i => i.status === 'error').length;
+
+  const getLabel = (): string => {
+    if (pending > 0) {
+      return `Running... (${completed}/${items.length})`;
+    }
+
+    if (error > 0) {
+      return `${completed} completed · ${error} failed`;
+    }
+
+    return `Completed ${items.length} steps`;
+  };
+
+  const getIndicatorClass = (): string => {
+    if (pending > 0) {
+      return styles.running;
+    }
+
+    if (error > 0) {
+      return styles.error;
+    }
+
+    return styles.done;
+  };
+
+  return (
+    <div className={styles.customCard}>
+      <button className={styles.customCardHeader} onClick={() => setExpanded(prev => !prev)}>
+        <span className={styles.customCardTitle}>
+          <span className={`${styles.customCardIndicator} ${getIndicatorClass()}`} />
+          {getLabel()}
+        </span>
+        <span className={`${styles.customCardChevron} ${expanded ? styles.expanded : ''}`}>▾</span>
+      </button>
+      {expanded && (
+        <div className={styles.customCardBody}>
+          {items.map(item => {
+            const cfg = statusConfig[item.status];
+
+            return (
+              <div key={item.id} className={styles.customCardStep}>
+                <span className={styles.customCardStepIcon} style={{ color: cfg.color }}>
+                  {cfg.icon}
+                </span>
+                <span className={styles.customCardStepName}>{item.label}</span>
+                <span
+                  className={styles.customCardStepBadge}
+                  style={{ backgroundColor: `${cfg.color}18`, color: cfg.color }}
+                >
+                  {cfg.label}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function getRenderToolCallGroup(
+  mode: RenderMode,
+):
+  | ((props: {
+      items: ToolCallItemData[];
+      time?: Date;
+      renderDefaultContent: (overrides?: { title?: string }) => ReactNode;
+    }) => ReactNode)
+  | undefined {
+  if (mode === 'hidden') return () => null;
+
+  if (mode === 'custom-title')
+    return ({ renderDefaultContent }) => renderDefaultContent({ title: 'AI is thinking...' });
+
+  if (mode === 'summary') return ({ items }) => <SummaryRenderer items={items} />;
+
+  if (mode === 'steps') return ({ items }) => <StepCardRenderer items={items} />;
+
+  return undefined;
+}
+
+export function ToolCallDemo(): ReactNode {
+  const [scenario, setScenario] = useState<Scenario>('completed');
+  const [selectedMode, setSelectedMode] = useState<RenderMode>('default');
+
+  return (
+    <DemoWrapper
+      title="Tool Call Renderer"
+      description='Customize or hide the "Answer preparation steps" UI using renderToolCallGroup.'
+    >
+      <div className={styles.controls}>
+        <h3>Tool Call Status</h3>
+        <div className={styles.scenarioList}>
+          {scenarioOptions.map(option => (
+            <button
+              key={option.value}
+              className={`${styles.scenarioButton} ${scenario === option.value ? styles.active : ''}`}
+              onClick={() => setScenario(option.value)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+
+        <h3>Usage Examples</h3>
+        <div className={styles.modeList}>
+          {modeOptions.map(option => (
+            <button
+              key={option.value}
+              className={`${styles.modeButton} ${selectedMode === option.value ? styles.active : ''}`}
+              onClick={() => setSelectedMode(option.value)}
+            >
+              <span className={styles.modeLabel}>{option.label}</span>
+              <span className={styles.modeDescription}>{option.description}</span>
+            </button>
+          ))}
+        </div>
+
+        <div className={styles.codePreview}>
+          <pre className={styles.code}>{codeExamples[selectedMode]}</pre>
+        </div>
+      </div>
+
+      <div className={styles.chatbotContainer}>
+        <Chatbot
+          key={`${scenario}-${selectedMode}`}
+          title="Tool Call Demo"
+          config={{ botProviderEndpoint: 'skip' }}
+          customChannelId={`tool-call-demo-${scenario}-${selectedMode}`}
+          initMessages={scenarioMessages[scenario]()}
+          autoResetChannel={false}
+          renderToolCallGroup={getRenderToolCallGroup(selectedMode)}
+        />
+      </div>
+    </DemoWrapper>
+  );
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -317,6 +317,7 @@ config: {
 - **renderHeader?**: `() => ReactNode` - Custom header renderer. When provided, completely replaces the default header. Use `useAsgardContext()` inside the render function to access `resetChannel`, `isResetting`, and other internal state.
 - **renderMenu?**: `() => ReactNode` - Custom menu renderer. When provided, renders content between the chat body and footer. Useful for quick menus, suggested questions, or navigation panels. See [Custom Menu](#custom-menu) section for details.
 - **renderMessageContent?**: `(props: MessageContentRendererProps) => ReactNode` - Custom renderer for message content. Allows customizing how messages are rendered based on message properties. See [Custom Message Renderer](#custom-message-renderer) section for details.
+- **renderToolCallGroup?**: `(props: ToolCallGroupRendererProps) => ReactNode` - Custom renderer for tool call group. Return `null` to hide, return JSX to fully customize, or call `renderDefaultContent()` to use the default UI with optional overrides (e.g., `renderDefaultContent({ title: 'AI is thinking...' })`). See [Tool Call Group Renderer](#tool-call-group-renderer) section for details.
 - **onBeforeSendMessage?**: `(params: SendMessageParams) => SendMessageParams` - Callback to modify message params before sending. Allows injecting contextual data (payload, metadata) from parent components. See [Before Send Message Hook](#before-send-message-hook) section for details.
 - **onSseMessage**: `(response: SseResponse, ctx: AsgardServiceContextValue) => void` - Callback function when SSE message is received. It would be helpful if using with the ref to provide some context and conversation data and do some proactively actions like sending messages to the bot.
 - **ref**: `ForwardedRef<ChatbotRef>` - Forwarded ref to access the chatbot instance. It can be used to access the chatbot instance and do some actions like sending messages to the bot. `ChatbotRef` provides `serviceContext` for interacting with the chatbot, and `setInputValue(value: string)` for programmatically setting the textarea text from outside the component.
@@ -829,6 +830,75 @@ messageActions={(message) => {
 
   return actions;
 }}
+```
+
+<a id="custom-message-renderer"></a>
+<br/>
+
+<a id="tool-call-group-renderer"></a>
+<br/>
+
+### Tool Call Group Renderer
+
+The `renderToolCallGroup` prop allows you to customize or hide the "Answer preparation steps" UI that appears when the bot calls tools before responding.
+
+#### ToolCallGroupRendererProps Interface
+
+```typescript
+interface ToolCallGroupRendererProps {
+  /** Tool call items in the group */
+  items: ToolCallItemData[];
+  /** Timestamp of the first tool call */
+  time?: Date;
+  /** Function to render the default tool call group UI. Accepts optional overrides. */
+  renderDefaultContent: (overrides?: { title?: string }) => ReactNode;
+}
+
+interface ToolCallItemData {
+  id: string;
+  label: string;
+  status: 'pending' | 'completed' | 'error';
+  initial?: Record<string, unknown>;
+  result?: Record<string, unknown>;
+}
+```
+
+#### Hide completely
+
+```typescript
+<Chatbot
+  renderToolCallGroup={() => null}
+  ...
+/>
+```
+
+#### Custom title
+
+```typescript
+<Chatbot
+  renderToolCallGroup={({ renderDefaultContent }) =>
+    renderDefaultContent({ title: 'AI is thinking...' })
+  }
+  ...
+/>
+```
+
+#### Custom UI
+
+```typescript
+<Chatbot
+  renderToolCallGroup={({ items }) => {
+    const done = items.filter(i => i.status === 'completed').length;
+    return (
+      <div>
+        {done === items.length
+          ? `✅ ${done} steps completed`
+          : `⏳ Processing...`}
+      </div>
+    );
+  }}
+  ...
+/>
 ```
 
 <a id="custom-message-renderer"></a>

--- a/packages/react/src/components/chatbot/chatbot-body/chatbot-body.tsx
+++ b/packages/react/src/components/chatbot/chatbot-body/chatbot-body.tsx
@@ -1,10 +1,11 @@
-import { ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
+import { Fragment, ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
 import { ConversationMessage, ConversationToolCallMessage } from '@asgard-js/core';
 import { useAsgardContext } from '../../../context/asgard-service-context';
 import styles from './chatbot-body.module.scss';
 import { ConversationMessageRenderer } from './conversation-message-renderer';
 import { BotTypingPlaceholder, ToolCallGroupTemplate, ToolCallItemData, ToolCallStatus } from '../../templates';
 import { useAsgardThemeContext } from '../../../context/asgard-theme-context';
+import { useAsgardTemplateContext } from '../../../context/asgard-template-context';
 import clsx from 'clsx';
 import { useResizeObserver } from '../../../hooks';
 
@@ -65,6 +66,7 @@ const BOTTOM_THRESHOLD = 50;
 
 export function ChatbotBody(): ReactNode {
   const { chatbot } = useAsgardThemeContext();
+  const { renderToolCallGroup } = useAsgardTemplateContext();
 
   const {
     messages,
@@ -149,14 +151,24 @@ export function ChatbotBody(): ReactNode {
             if (group.type === 'tool-call-group') {
               const items = group.toolCalls.map(toolCallToItemData);
               const firstToolCall = group.toolCalls[0];
+              const key = `tool-call-group-${firstToolCall?.processId || index}`;
 
-              return (
-                <ToolCallGroupTemplate
-                  key={`tool-call-group-${firstToolCall?.processId || index}`}
-                  items={items}
-                  time={firstToolCall?.time}
-                />
+              const renderDefaultContent = (overrides?: { title?: string }): ReactNode => (
+                <ToolCallGroupTemplate items={items} time={firstToolCall?.time} title={overrides?.title} />
               );
+
+              if (renderToolCallGroup) {
+                const custom = renderToolCallGroup({
+                  items,
+                  time: firstToolCall?.time,
+                  renderDefaultContent,
+                });
+                if (custom === null) return null;
+
+                return <Fragment key={key}>{custom}</Fragment>;
+              }
+
+              return <Fragment key={key}>{renderDefaultContent()}</Fragment>;
             }
 
             return (

--- a/packages/react/src/components/chatbot/chatbot.tsx
+++ b/packages/react/src/components/chatbot/chatbot.tsx
@@ -77,6 +77,9 @@ interface ChatbotProps extends AsgardTemplateContextValue {
   /** Custom menu renderer. When provided, renders between chat body and footer. */
   renderMenu?: () => ReactNode;
 
+  /** Custom renderer for tool call group. Return null to hide, or return custom JSX. */
+  renderToolCallGroup?: AsgardTemplateContextValue['renderToolCallGroup'];
+
   /** Whether to automatically reset channel on mount. Defaults to true. When false, the channel is created without sending RESET_CHANNEL, allowing history messages to be preserved via initMessages. */
   autoResetChannel?: boolean;
 }
@@ -125,6 +128,7 @@ export const Chatbot = forwardRef(function Chatbot(props: ChatbotProps, ref: For
     onMessageSent,
     renderHeader,
     renderMenu,
+    renderToolCallGroup,
     autoResetChannel,
   } = props;
 
@@ -257,6 +261,7 @@ export const Chatbot = forwardRef(function Chatbot(props: ChatbotProps, ref: For
               messageActions={messageActions}
               onMessageAction={onMessageAction}
               renderMessageContent={renderMessageContent}
+              renderToolCallGroup={renderToolCallGroup}
             >
               <ChatbotBody />
             </AsgardTemplateContextProvider>

--- a/packages/react/src/context/asgard-template-context.tsx
+++ b/packages/react/src/context/asgard-template-context.tsx
@@ -1,5 +1,6 @@
 import { createContext, FC, PropsWithChildren, ReactNode, useContext, useMemo } from 'react';
 import { ConversationBotMessage, ConversationErrorMessage, ConversationMessage } from '@asgard-js/core';
+import { ToolCallItemData } from '../components/templates';
 
 /**
  * Configuration for a message action button
@@ -30,6 +31,18 @@ export interface MessageContentRendererProps {
   MessageContainer: FC<MessageContainerProps>;
 }
 
+/**
+ * Props passed to the custom tool call group renderer function
+ */
+export interface ToolCallGroupRendererProps {
+  /** Tool call items in the group */
+  items: ToolCallItemData[];
+  /** Timestamp of the first tool call */
+  time?: Date;
+  /** Function to render the default tool call group UI. Accepts optional overrides. */
+  renderDefaultContent: (overrides?: { title?: string }) => ReactNode;
+}
+
 export interface AsgardTemplateContextValue {
   onErrorClick?: (message: ConversationErrorMessage) => void;
   errorMessageRenderer?: (message: ConversationErrorMessage) => ReactNode;
@@ -41,6 +54,8 @@ export interface AsgardTemplateContextValue {
   onMessageAction?: (actionId: string, message: ConversationBotMessage) => void;
   /** Custom renderer for message content. Allows customizing how messages are rendered based on message properties. */
   renderMessageContent?: (props: MessageContentRendererProps) => ReactNode;
+  /** Custom renderer for tool call group. Return null to hide, or return custom JSX. */
+  renderToolCallGroup?: (props: ToolCallGroupRendererProps) => ReactNode;
 }
 
 export const AsgardTemplateContext = createContext<AsgardTemplateContextValue>({
@@ -51,6 +66,7 @@ export const AsgardTemplateContext = createContext<AsgardTemplateContextValue>({
   messageActions: undefined,
   onMessageAction: undefined,
   renderMessageContent: undefined,
+  renderToolCallGroup: undefined,
 });
 
 interface AsgardTemplateContextProviderProps extends PropsWithChildren {
@@ -61,6 +77,7 @@ interface AsgardTemplateContextProviderProps extends PropsWithChildren {
   messageActions?: (message: ConversationBotMessage) => MessageActionConfig[];
   onMessageAction?: (actionId: string, message: ConversationBotMessage) => void;
   renderMessageContent?: (props: MessageContentRendererProps) => ReactNode;
+  renderToolCallGroup?: (props: ToolCallGroupRendererProps) => ReactNode;
 }
 
 export function AsgardTemplateContextProvider(props: AsgardTemplateContextProviderProps): ReactNode {
@@ -73,6 +90,7 @@ export function AsgardTemplateContextProvider(props: AsgardTemplateContextProvid
     messageActions,
     onMessageAction,
     renderMessageContent,
+    renderToolCallGroup,
   } = props;
 
   const contextValue = useMemo(
@@ -84,6 +102,7 @@ export function AsgardTemplateContextProvider(props: AsgardTemplateContextProvid
       messageActions,
       onMessageAction,
       renderMessageContent,
+      renderToolCallGroup,
     }),
     [
       errorMessageRenderer,
@@ -93,6 +112,7 @@ export function AsgardTemplateContextProvider(props: AsgardTemplateContextProvid
       messageActions,
       onMessageAction,
       renderMessageContent,
+      renderToolCallGroup,
     ],
   );
 


### PR DESCRIPTION
## Summary
- 新增 `renderToolCallGroup` prop，讓整合方可以隱藏或自訂 Tool Call Group（Answer preparation steps）的渲染方式
- 回傳 `null` 即隱藏，回傳 JSX 即自訂渲染，不設則維持預設行為
- react-demo 新增 Tool Call 頁面，展示 Default / Hidden / Summary / Step Card 四種模式

## API
```tsx
renderToolCallGroup?: (
  items: ToolCallItemData[],
  context: { time?: Date; defaultRender: () => ReactNode },
) => ReactNode;
```

## Test plan
- [ ] `renderToolCallGroup` 不設時，行為與改動前一致
- [ ] `renderToolCallGroup={() => null}` 隱藏 tool call group
- [ ] 自訂 renderer 正確接收 items 資料並渲染
- [ ] `defaultRender()` 可正常呼叫並渲染預設 UI
- [ ] react-demo `/tool-call` 頁面四種模式切換正常