### PR TITLE
fix(react): make chatbot body row fill remaining height

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asgard-js/react",
-  "version": "0.2.34",
+  "version": "0.2.35-canary.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/react/src/components/chatbot/chatbot-container/chatbot-container.module.scss
+++ b/packages/react/src/components/chatbot/chatbot-container/chatbot-container.module.scss
@@ -27,7 +27,7 @@
 
 .chatbot_container {
   display: grid;
-  grid-template-rows: max-content auto max-content max-content;
+  grid-template-rows: max-content 1fr max-content max-content;
   background-color: var(--asg-color-bg);
   overflow: hidden;
   overscroll-behavior: contain;


### PR DESCRIPTION
## 問題

`chatbot_container` 目前用：

```scss
grid-template-rows: max-content auto max-content max-content;
```

CSS Grid 的 `auto` track 只會照內容大小，不會吸收剩餘空間（那是 `1fr` 的行為）。所以：

- ✅ 容器高度 = 內容高度：看起來正常
- ❌ 容器高度 > 內容高度：footer 黏在最後一則訊息後面，下方會有一塊空白

只要把 Chatbot 嵌進比內容高的容器（例如 resizable split pane、固定尺寸的 section），就會看到 footer 浮在中間、下方留白的問題。

## 修正

把 body row 從 `auto` 改成 `1fr`：

```diff
- grid-template-rows: max-content auto max-content max-content;
+ grid-template-rows: max-content 1fr max-content max-content;
```

`1fr` 會吸收剩餘高度，讓 footer 在任何高度的容器中都貼底；訊息超出時也會自然觸發 body 內部滾動（`chatbot_body` 已經有 `overflow-y: scroll`）。

## 影響範圍

單行 CSS，沒有 JS 行為變動。已有 layout：

- 容器高度 = 內容：和原本一樣
- 容器高度 > 內容：**修正成貼底**（原本浮在中間）
- 容器高度 < 內容：和原本一樣（body 滾動）

## Test Plan

- [ ] 在高度剛好的容器中（例如 `full_screen` 模式）確認 footer 依然貼底
- [ ] 在比內容高的容器中（例如 `height: 100vh` 且訊息很少）確認 footer 貼底、不再浮中間
- [ ] 送大量訊息讓 body 超過容器高度，確認 body 可以正常滾動