### PR TITLE
Revert "fix(react): make chatbot body row fill remaining height (#237)"

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asgard-js/react",
-  "version": "0.2.35-canary.1",
+  "version": "0.2.34",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/react/src/components/chatbot/chatbot-container/chatbot-container.module.scss
+++ b/packages/react/src/components/chatbot/chatbot-container/chatbot-container.module.scss
@@ -27,7 +27,7 @@
 
 .chatbot_container {
   display: grid;
-  grid-template-rows: max-content 1fr max-content max-content;
+  grid-template-rows: max-content auto max-content max-content;
   background-color: var(--asg-color-bg);
   overflow: hidden;
   overscroll-behavior: contain;


### PR DESCRIPTION
還原 #237 的 merge commit。原 PR 不小心在尚未準備好的狀態被 merge，本 PR 將 main 回復到合併前的狀態。

fix 分支 `fix/chatbot-container-fill-height` 仍保留，後續準備好再重新送 PR 合併。

## 備註

- 這支 revert 不影響 npm 已發佈的 `@asgard-js/react@0.2.35-canary.1`（canary tarball 已經在 registry 上）。
- 若之後要重新 merge，把原 fix 分支 rebase 到最新 main 再開新 PR 即可。