### PR TITLE
fix(react): make chatbot fill parent height in flex containers

### DIFF
--- a/packages/react/src/components/chatbot/chatbot-container/chatbot-container.module.scss
+++ b/packages/react/src/components/chatbot/chatbot-container/chatbot-container.module.scss
@@ -7,6 +7,11 @@
 
   font-family: 'Space Grotesk', 'Noto Sans TC', sans-serif;
 
+  // Allow the root to shrink below its content size when used as a flex child.
+  // Without this, the default `min-height: auto` pins the root to its intrinsic
+  // content height and overflows the parent (e.g. in a flex-column wrapper).
+  min-height: 0;
+
   * {
     line-height: 1.5;
     box-sizing: border-box;
@@ -27,7 +32,7 @@
 
 .chatbot_container {
   display: grid;
-  grid-template-rows: max-content auto max-content max-content;
+  grid-template-rows: max-content 1fr max-content max-content;
   background-color: var(--asg-color-bg);
   overflow: hidden;
   overscroll-behavior: contain;

--- a/packages/react/src/components/chatbot/chatbot-container/chatbot-container.module.scss
+++ b/packages/react/src/components/chatbot/chatbot-container/chatbot-container.module.scss
@@ -7,6 +7,11 @@
 
   font-family: 'Space Grotesk', 'Noto Sans TC', sans-serif;
 
+  // Fill the parent when it has a definite height. Falls back to `auto`
+  // when the parent's height is indefinite, so this is a safe default for
+  // block-level usage too.
+  height: 100%;
+
   // Allow the root to shrink below its content size when used as a flex child.
   // Without this, the default `min-height: auto` pins the root to its intrinsic
   // content height and overflows the parent (e.g. in a flex-column wrapper).


### PR DESCRIPTION
修掉 `<Chatbot>` 塞進有 definite height 的 flex 容器（例如 resizable split pane）時，footer 不貼底、還會隨內容串流位移的問題。

## 三個 CSS 修正（缺一不可）

1. **`.chatbot_container` body row 從 `auto` 改成 `1fr`**
   `auto` 照內容大小、不吸收剩餘空間；改 `1fr` 才會把 footer 推到底。

2. **`.chatbot_root` 加 `min-height: 0`**
   flex child 預設 `min-height: auto` = 內容大小，阻止 root 縮到父層高度以下。

3. **`.chatbot_root` 加 `height: 100%`**
   父層有 definite height 時 root 直接填滿；父層高度不定時 `100%` fallback 成 `auto`，對 block-level 使用者行為不變。只有 (2) 沒有 (3)，root 會跟著內容動態長大，造成初始 footer 浮中間。

## 驗證

在 auto-post-web 的 desktop split view 實測，從 Chatbot 掛載第 0 毫秒起，grid 就是 `53px 636px 65px 0px`，footer bottom = container bottom（gap = 0）。

已發佈 `@asgard-js/react@0.2.35-canary.3` 供測試。

## Test Plan

- [ ] `fullScreen` 模式不回歸
- [ ] flex column 父層 + 訊息少：footer 從第一個 frame 就貼底
- [ ] flex column 父層 + 訊息多：body 內部滾動、footer 仍貼底
- [ ] block-level 父層：行為不變