### PR TITLE
feat: add userIdentityHint prop to Chatbot and ClientConfig

### DIFF
--- a/apps/react-demo/src/app/app.tsx
+++ b/apps/react-demo/src/app/app.tsx
@@ -19,6 +19,7 @@ import { HttpErrorDemo } from './routes/http-error';
 import { HttpErrorOnSendDemo } from './routes/http-error-on-send';
 import { ToolCallDemo } from './routes/tool-call';
 import { ToolCallConsentDemo } from './routes/tool-call-consent';
+import { UserIdentityHint } from './routes/user-identity-hint';
 
 export function App(): React.ReactElement {
   return (
@@ -43,6 +44,7 @@ export function App(): React.ReactElement {
         <Route path="/http-error-on-send" element={<HttpErrorOnSendDemo />} />
         <Route path="/tool-call" element={<ToolCallDemo />} />
         <Route path="/tool-call-consent" element={<ToolCallConsentDemo />} />
+        <Route path="/user-identity-hint" element={<UserIdentityHint />} />
       </Routes>
     </Layout>
   );

--- a/apps/react-demo/src/app/components/layout/layout.tsx
+++ b/apps/react-demo/src/app/components/layout/layout.tsx
@@ -25,6 +25,7 @@ const navItems = [
   { to: '/http-error-on-send', label: 'HTTP Error on Send' },
   { to: '/tool-call', label: 'Tool Call' },
   { to: '/tool-call-consent', label: 'Tool Call Consent' },
+  { to: '/user-identity-hint', label: 'User Identity Hint' },
 ];
 
 export function Layout({ children }: LayoutProps): ReactNode {

--- a/apps/react-demo/src/app/routes/user-identity-hint/index.ts
+++ b/apps/react-demo/src/app/routes/user-identity-hint/index.ts
@@ -1,0 +1,1 @@
+export { UserIdentityHint } from './user-identity-hint';

--- a/apps/react-demo/src/app/routes/user-identity-hint/user-identity-hint.module.scss
+++ b/apps/react-demo/src/app/routes/user-identity-hint/user-identity-hint.module.scss
@@ -1,0 +1,112 @@
+.controls {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  width: 320px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-height: 600px;
+  overflow-y: auto;
+}
+
+.section {
+  h3 {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1a1a2e;
+    margin: 0 0 8px 0;
+  }
+}
+
+.sectionDesc {
+  font-size: 13px;
+  color: #666;
+  margin: 0 0 12px 0;
+  line-height: 1.5;
+}
+
+.inputRow {
+  display: flex;
+  gap: 8px;
+}
+
+.input {
+  flex: 1;
+  padding: 8px 12px;
+  font-size: 13px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  outline: none;
+
+  &:focus {
+    border-color: #6366f1;
+  }
+}
+
+.applyButton {
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  color: white;
+  background: #6366f1;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: #4f46e5;
+  }
+}
+
+.headerPreview {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: #f5f5f5;
+  border-radius: 8px;
+  padding: 12px;
+  border-left: 3px solid #6366f1;
+}
+
+.headerKey {
+  font-size: 11px;
+  font-weight: 600;
+  color: #999;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.headerValue {
+  font-size: 14px;
+  font-weight: 500;
+  color: #6366f1;
+  word-break: break-all;
+}
+
+.code {
+  background: #1a1a2e;
+  color: #e0e0e0;
+  padding: 16px;
+  border-radius: 8px;
+  font-size: 12px;
+  margin: 0;
+  overflow-x: auto;
+  line-height: 1.6;
+}
+
+.chatbotContainer {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+
+  > div {
+    width: 100%;
+    max-width: 420px;
+    height: 600px;
+  }
+}

--- a/apps/react-demo/src/app/routes/user-identity-hint/user-identity-hint.tsx
+++ b/apps/react-demo/src/app/routes/user-identity-hint/user-identity-hint.tsx
@@ -1,0 +1,75 @@
+import { ReactNode, useState } from 'react';
+import { Chatbot } from '@asgard-js/react';
+import '@asgard-js/react/style';
+import { DemoWrapper } from '../../components/demo-wrapper';
+import { createTextTemplateExample } from '../../mocks/messages';
+import styles from './user-identity-hint.module.scss';
+
+export function UserIdentityHint(): ReactNode {
+  const [inputValue, setInputValue] = useState('user-123');
+  const [appliedHint, setAppliedHint] = useState('user-123');
+
+  const handleApply = (): void => {
+    setAppliedHint(inputValue);
+  };
+
+  const initMessages = [createTextTemplateExample()];
+
+  return (
+    <DemoWrapper
+      title="User Identity Hint"
+      description="When userIdentityHint is set, all requests include the X-ASGARD-USER-IDENTITY-HINT header."
+    >
+      <div className={styles.controls}>
+        <div className={styles.section}>
+          <h3>Set Identity Hint</h3>
+          <p className={styles.sectionDesc}>
+            Enter a value and click Apply. The chatbot will be remounted with the new <code>userIdentityHint</code>{' '}
+            prop.
+          </p>
+          <div className={styles.inputRow}>
+            <input
+              className={styles.input}
+              value={inputValue}
+              onChange={e => setInputValue(e.target.value)}
+              placeholder="e.g. user-123"
+            />
+            <button className={styles.applyButton} onClick={handleApply}>
+              Apply
+            </button>
+          </div>
+        </div>
+
+        <div className={styles.section}>
+          <h3>Current Header</h3>
+          <div className={styles.headerPreview}>
+            <span className={styles.headerKey}>X-ASGARD-USER-IDENTITY-HINT</span>
+            <span className={styles.headerValue}>{appliedHint || '(not set)'}</span>
+          </div>
+        </div>
+
+        <div className={styles.section}>
+          <h3>Code Example</h3>
+          <pre className={styles.code}>{`<Chatbot
+  userIdentityHint="${appliedHint}"
+  config={{
+    botProviderEndpoint: '...',
+  }}
+  customChannelId="my-channel"
+/>`}</pre>
+        </div>
+      </div>
+
+      <div className={styles.chatbotContainer}>
+        <Chatbot
+          key={appliedHint}
+          title="Identity Hint Demo"
+          config={{ botProviderEndpoint: import.meta.env.VITE_SIMPLE_BOT_PROVIDER_ENDPOINT }}
+          customChannelId="user-identity-hint-demo"
+          userIdentityHint={appliedHint || undefined}
+          initMessages={initMessages}
+        />
+      </div>
+    </DemoWrapper>
+  );
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -131,6 +131,7 @@ The main client class for interacting with the Asgard AI platform.
 - **debugMode?**: `boolean` - Enable debug mode for deprecation warnings, defaults to `false`
 - **transformSsePayload?**: `(payload: FetchSsePayload) => FetchSsePayload` - SSE payload transformer
 - **customHeaders?**: `Record<string, string>` - Custom headers to include in SSE and API requests (e.g., Bearer token via `Authorization` header)
+- **userIdentityHint?**: `string` - Optional user identity hint. When provided, all requests will include the `X-ASGARD-USER-IDENTITY-HINT` header with this value
 - **onRunInit?**: `InitEventHandler` - Handler for run initialization events
 - **onMessage?**: `MessageEventHandler` - Handler for message events
 - **onToolCall?**: `ToolCallEventHandler` - Handler for tool call events

--- a/packages/core/src/lib/client.ts
+++ b/packages/core/src/lib/client.ts
@@ -32,7 +32,10 @@ export default class AsgardServiceClient implements IAsgardServiceClient {
     this.debugMode = config.debugMode;
     this.transformSsePayload = config.transformSsePayload;
     this.botProviderEndpoint = config.botProviderEndpoint;
-    this.customHeaders = config.customHeaders;
+    this.customHeaders = {
+      ...config.customHeaders,
+      ...(config.userIdentityHint ? { 'X-ASGARD-USER-IDENTITY-HINT': config.userIdentityHint } : {}),
+    };
 
     // Handle endpoint derivation and deprecation
     if (!config.endpoint && config.botProviderEndpoint) {

--- a/packages/core/src/types/client.ts
+++ b/packages/core/src/types/client.ts
@@ -42,6 +42,11 @@ export type ClientConfig = SseHandlers & {
    * }
    */
   customHeaders?: Record<string, string>;
+  /**
+   * Optional user identity hint. When provided, all requests will include the
+   * `X-ASGARD-USER-IDENTITY-HINT` header with this value.
+   */
+  userIdentityHint?: string;
 } & (
     | {
         /**

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -283,6 +283,7 @@ config: {
   - `endpoint?`: `string` (deprecated) - Legacy API endpoint URL. Use `botProviderEndpoint` instead.
   - `transformSsePayload?`: `(payload: FetchSsePayload) => FetchSsePayload` - SSE payload transformer
   - `customHeaders?`: `Record<string, string>` - Custom headers to include in SSE and API requests (e.g., Bearer token via `Authorization` header)
+  - `userIdentityHint?`: `string` - Optional user identity hint. When provided, all requests will include the `X-ASGARD-USER-IDENTITY-HINT` header with this value
   - `debugMode?`: `boolean` - Enable debug mode, defaults to `false`
   - `onRunInit?`: `InitEventHandler` - Handler for run initialization events
   - `onMessage?`: `MessageEventHandler` - Handler for message events
@@ -306,6 +307,7 @@ config: {
 - **defaultLinkTarget?**: `'_blank' | '_self' | '_parent' | '_top'` - Default target for opening URIs when not specified by the API. Defaults to `'_blank'` (opens in new tab).
 - **theme**: `Partial<AsgardThemeContextValue>` - Custom theme configuration
 - **autoResetChannel?**: `boolean` - Whether to automatically reset channel on mount. Defaults to `true`. When set to `false`, the channel is created without sending `RESET_CHANNEL`, preserving history messages loaded via `initMessages`. See [Auto Reset Channel](#auto-reset-channel) section for details.
+- **userIdentityHint?**: `string` - Optional user identity hint. When provided, all requests (SSE and file upload) will include the `X-ASGARD-USER-IDENTITY-HINT` header with this value.
 - **onMessageSent?**: `() => void` - Callback fired after a message is successfully sent. Useful for tracking message count or triggering side effects.
 - **onReset**: `() => void` - Callback function when chat is reset
 - **onClose**: `() => void` - Callback function when chat is closed

--- a/packages/react/src/components/chatbot/chatbot.tsx
+++ b/packages/react/src/components/chatbot/chatbot.tsx
@@ -83,6 +83,9 @@ interface ChatbotProps extends AsgardTemplateContextValue {
 
   /** Whether to automatically reset channel on mount. Defaults to true. When false, the channel is created without sending RESET_CHANNEL, allowing history messages to be preserved via initMessages. */
   autoResetChannel?: boolean;
+
+  /** Optional user identity hint. When provided, all requests will include the `X-ASGARD-USER-IDENTITY-HINT` header. */
+  userIdentityHint?: string;
 }
 
 export interface ChatbotRef {
@@ -131,7 +134,10 @@ export const Chatbot = forwardRef(function Chatbot(props: ChatbotProps, ref: For
     renderMenu,
     renderToolCallGroup,
     autoResetChannel,
+    userIdentityHint,
   } = props;
+
+  const effectiveConfig = userIdentityHint ? { ...config, userIdentityHint } : config;
 
   const dragCounterRef = useRef(0);
   const fileDropRef = useRef<{
@@ -285,7 +291,7 @@ export const Chatbot = forwardRef(function Chatbot(props: ChatbotProps, ref: For
     return (
       <AsgardAppInitializationContextProvider
         enabled={enableLoadConfigFromService}
-        config={config}
+        config={effectiveConfig}
         asyncInitializers={asyncInitializers}
         loadingComponent={loadingComponent}
       >
@@ -294,7 +300,7 @@ export const Chatbot = forwardRef(function Chatbot(props: ChatbotProps, ref: For
             parentRef={ref}
             avatar={avatar}
             title={title}
-            config={config}
+            config={effectiveConfig}
             customChannelId={customChannelId}
             initMessages={initMessages}
             onSseMessage={onSseMessage}


### PR DESCRIPTION
## Summary
- `@asgard-js/core`：`ClientConfig` 新增 optional field `userIdentityHint?: string`
- `@asgard-js/core`：`AsgardServiceClient` constructor 將 `userIdentityHint` 合併進 custom headers，key 為 `X-ASGARD-USER-IDENTITY-HINT`，SSE 請求與檔案上傳皆自動帶上此 header
- `@asgard-js/react`：`Chatbot` component 新增 optional prop `userIdentityHint?: string`，傳入時自動合併進 config

## ClickUp
- SDK Chat加入新 prop (optional): userIdentityHint: https://app.clickup.com/t/86ex9pdr3

## Test plan
- [ ] 傳入 `userIdentityHint` 後，SSE 請求的 headers 包含 `X-ASGARD-USER-IDENTITY-HINT`
- [ ] 不傳 `userIdentityHint` 時，行為與原本相同（無多餘 header）
- [ ] 與 `customHeaders` 同時使用時，兩者都正確帶上