### PR TITLE
feat: add onChannelReady callback to Chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ SDK for integrating AI chatbots with the [Asgard AI](https://asgard-ai.com) plat
     - [Chatbot Component Props](./packages/react/README.md#chatbot-component-props)
     - [Theme Configuration](./packages/react/README.md#theme-configuration)
   - [Event Handlers](./packages/react/README.md#event-handlers)
+    - [On Channel Ready](./packages/react/README.md#on-channel-ready)
     - [Tool Call Handler](./packages/react/README.md#tool-call-handler)
     - [Tool Call Consent](./packages/react/README.md#tool-call-consent)
     - [EMIT Action](./packages/react/README.md#emit-action)

--- a/apps/react-demo/src/app/app.tsx
+++ b/apps/react-demo/src/app/app.tsx
@@ -20,6 +20,7 @@ import { HttpErrorOnSendDemo } from './routes/http-error-on-send';
 import { ToolCallDemo } from './routes/tool-call';
 import { ToolCallConsentDemo } from './routes/tool-call-consent';
 import { UserIdentityHint } from './routes/user-identity-hint';
+import { OnChannelReady } from './routes/on-channel-ready';
 
 export function App(): React.ReactElement {
   return (
@@ -45,6 +46,7 @@ export function App(): React.ReactElement {
         <Route path="/tool-call" element={<ToolCallDemo />} />
         <Route path="/tool-call-consent" element={<ToolCallConsentDemo />} />
         <Route path="/user-identity-hint" element={<UserIdentityHint />} />
+        <Route path="/on-channel-ready" element={<OnChannelReady />} />
       </Routes>
     </Layout>
   );

--- a/apps/react-demo/src/app/components/layout/layout.tsx
+++ b/apps/react-demo/src/app/components/layout/layout.tsx
@@ -26,6 +26,7 @@ const navItems = [
   { to: '/tool-call', label: 'Tool Call' },
   { to: '/tool-call-consent', label: 'Tool Call Consent' },
   { to: '/user-identity-hint', label: 'User Identity Hint' },
+  { to: '/on-channel-ready', label: 'On Channel Ready' },
 ];
 
 export function Layout({ children }: LayoutProps): ReactNode {

--- a/apps/react-demo/src/app/routes/on-channel-ready/index.ts
+++ b/apps/react-demo/src/app/routes/on-channel-ready/index.ts
@@ -1,0 +1,1 @@
+export * from './on-channel-ready';

--- a/apps/react-demo/src/app/routes/on-channel-ready/on-channel-ready.module.scss
+++ b/apps/react-demo/src/app/routes/on-channel-ready/on-channel-ready.module.scss
@@ -1,0 +1,103 @@
+.controls {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  width: 320px;
+  flex-shrink: 0;
+
+  h3 {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1a1a2e;
+    margin: 0 0 16px 0;
+  }
+}
+
+.toggles {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #333;
+
+  input {
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+  }
+}
+
+.remountButton {
+  margin-top: 16px;
+  width: 100%;
+  padding: 10px 16px;
+  background: #1a1a2e;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    background: #2d2d4e;
+  }
+}
+
+.info {
+  margin-top: 24px;
+  padding-top: 24px;
+  border-top: 1px solid #e0e0e0;
+
+  h4 {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1a1a2e;
+    margin: 0 0 12px 0;
+  }
+
+  pre {
+    background: #f5f5f5;
+    padding: 12px;
+    border-radius: 8px;
+    font-size: 12px;
+    margin: 0;
+    overflow-x: auto;
+    max-height: 200px;
+  }
+
+  code {
+    background: #f5f5f5;
+    padding: 2px 4px;
+    border-radius: 4px;
+    font-size: 12px;
+  }
+}
+
+.description {
+  font-size: 13px;
+  color: #555;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.chatbotContainer {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+
+  > div {
+    width: 100%;
+    max-width: 420px;
+    height: 600px;
+  }
+}

--- a/apps/react-demo/src/app/routes/on-channel-ready/on-channel-ready.tsx
+++ b/apps/react-demo/src/app/routes/on-channel-ready/on-channel-ready.tsx
@@ -1,0 +1,95 @@
+import { ReactNode, useCallback, useRef, useState } from 'react';
+import { Chatbot, ChatbotRef } from '@asgard-js/react';
+import '@asgard-js/react/style';
+import { DemoWrapper } from '../../components/demo-wrapper';
+import styles from './on-channel-ready.module.scss';
+
+interface ReadyEvent {
+  at: number;
+  sendMessageAvailable: boolean;
+  serviceContextAvailable: boolean;
+}
+
+export function OnChannelReady(): ReactNode {
+  const chatbotRef = useRef<ChatbotRef>(null);
+  const [key, setKey] = useState(0);
+  const [autoSend, setAutoSend] = useState(true);
+  const [events, setEvents] = useState<ReadyEvent[]>([]);
+
+  const handleChannelReady = useCallback((): void => {
+    const ctx = chatbotRef.current?.serviceContext;
+    const event: ReadyEvent = {
+      at: performance.now(),
+      sendMessageAvailable: typeof ctx?.sendMessage === 'function',
+      serviceContextAvailable: !!ctx,
+    };
+    setEvents(prev => [...prev, event]);
+
+    if (autoSend && ctx?.sendMessage) {
+      void ctx.sendMessage({
+        text: 'auto-sent on channel ready',
+        blobIds: [],
+      });
+    }
+  }, [autoSend]);
+
+  const handleRemount = (): void => {
+    setEvents([]);
+    setKey(prev => prev + 1);
+  };
+
+  const handleResetChannel = (): void => {
+    void chatbotRef.current?.serviceContext?.resetChannel?.();
+  };
+
+  return (
+    <DemoWrapper
+      title="onChannelReady"
+      description="Fires once the chat channel is ready to accept messages. Re-fires after channel reset. Use this instead of polling for sendMessage availability."
+    >
+      <div className={styles.controls}>
+        <h3>Settings</h3>
+        <div className={styles.toggles}>
+          <label className={styles.toggle}>
+            <input type="checkbox" checked={autoSend} onChange={() => setAutoSend(prev => !prev)} />
+            <span>Auto-send a message on ready</span>
+          </label>
+          <button className={styles.remountButton} onClick={handleRemount}>
+            Remount Chatbot (key change)
+          </button>
+          <button className={styles.remountButton} onClick={handleResetChannel}>
+            Reset Channel (in-place)
+          </button>
+        </div>
+
+        <div className={styles.info}>
+          <h4>Ready events ({events.length})</h4>
+          {events.length === 0 ? (
+            <p className={styles.description}>Waiting for first onChannelReady...</p>
+          ) : (
+            <pre>{JSON.stringify(events, null, 2)}</pre>
+          )}
+        </div>
+
+        <div className={styles.info}>
+          <h4>Verification</h4>
+          <p className={styles.description}>
+            Each event records whether <code>ref.current.serviceContext.sendMessage</code> was a function at the moment
+            the callback fired. Both flags should be <code>true</code> on every fire.
+          </p>
+        </div>
+      </div>
+
+      <div className={styles.chatbotContainer}>
+        <Chatbot
+          key={key}
+          ref={chatbotRef}
+          title="onChannelReady Demo"
+          config={{ botProviderEndpoint: import.meta.env.VITE_SIMPLE_BOT_PROVIDER_ENDPOINT }}
+          customChannelId="on-channel-ready-demo"
+          onChannelReady={handleChannelReady}
+        />
+      </div>
+    </DemoWrapper>
+  );
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -309,6 +309,7 @@ config: {
 - **autoResetChannel?**: `boolean` - Whether to automatically reset channel on mount. Defaults to `true`. When set to `false`, the channel is created without sending `RESET_CHANNEL`, preserving history messages loaded via `initMessages`. See [Auto Reset Channel](#auto-reset-channel) section for details.
 - **userIdentityHint?**: `string` - Optional user identity hint. When provided, all requests (SSE and file upload) will include the `X-ASGARD-USER-IDENTITY-HINT` header with this value.
 - **onMessageSent?**: `() => void` - Callback fired after a message is successfully sent. Useful for tracking message count or triggering side effects.
+- **onChannelReady?**: `() => void` - Callback fired once the chat channel is ready to accept messages. Use this instead of polling for `sendMessage` availability when you need to send an initial message right after the chatbot mounts. Re-fires after channel reset. See [On Channel Ready](#on-channel-ready) section for details.
 - **onReset**: `() => void` - Callback function when chat is reset
 - **onClose**: `() => void` - Callback function when chat is closed
 - **authState?**: `AuthState` - Authentication state for dynamic API key management. Available states: `'loading'`, `'needApiKey'`, `'authenticated'`, `'error'`, `'invalidApiKey'`
@@ -589,6 +590,65 @@ Note: When `fullScreen` prop is set to `true`, the chatbot's width and height wi
 <br/>
 
 ## Event Handlers
+
+<a id="on-channel-ready"></a>
+<br/>
+
+### On Channel Ready
+
+The `onChannelReady` callback fires once the chat channel is fully initialized and ready to accept messages. This is useful when you need to send an initial message right after the chatbot mounts — for example, when seeding a chat with a SQL statement carried over from another page.
+
+#### Why not call `sendMessage` from a `useEffect`?
+
+Channel initialization happens asynchronously after mount. The `serviceContext.sendMessage` exposed via `ref` becomes a function before the underlying channel is actually ready, so calling it too early results in a silent no-op. `onChannelReady` solves this by guaranteeing the callback fires only after the channel can receive messages.
+
+#### Behavior
+
+- Fires once after the channel is created and the imperative ref has been updated
+- Re-fires after a manual `resetChannel` (channel transitions from non-null → null → non-null)
+- Inside the callback, `ref.current.serviceContext.sendMessage` is guaranteed to be a working function bound to the new channel
+
+#### Usage Example
+
+```tsx
+import { Chatbot, ChatbotRef } from '@asgard-js/react';
+import { useCallback, useRef } from 'react';
+
+function MyChatbot({ initialText }: { initialText?: string }) {
+  const chatbotRef = useRef<ChatbotRef>(null);
+
+  const handleChannelReady = useCallback(() => {
+    if (initialText) {
+      chatbotRef.current?.serviceContext?.sendMessage?.({
+        text: initialText,
+        blobIds: [],
+      });
+    }
+  }, [initialText]);
+
+  return (
+    <Chatbot
+      ref={chatbotRef}
+      config={{ botProviderEndpoint: '...' }}
+      customChannelId="my-channel"
+      onChannelReady={handleChannelReady}
+    />
+  );
+}
+```
+
+#### Single-fire vs. Re-fire
+
+If you want the work to happen only on the first ready (not after subsequent resets), use a ref guard in your callback:
+
+```tsx
+const firedRef = useRef(false);
+const handleChannelReady = useCallback(() => {
+  if (firedRef.current) return;
+  firedRef.current = true;
+  // do one-time work here
+}, []);
+```
 
 <a id="tool-call-handler"></a>
 <br/>

--- a/packages/react/src/components/chatbot/chatbot.tsx
+++ b/packages/react/src/components/chatbot/chatbot.tsx
@@ -72,6 +72,17 @@ interface ChatbotProps extends AsgardTemplateContextValue {
   /** Callback fired after a message has been sent */
   onMessageSent?: () => void;
 
+  /**
+   * Fired once the chat channel is ready to accept messages. Triggered after
+   * the underlying Channel instance is created and the imperative ref has
+   * been updated, which guarantees calling
+   * `ref.current.serviceContext.sendMessage` from inside the callback works.
+   *
+   * Re-fires when the channel is replaced (e.g. after `resetChannel`). Use a
+   * guard ref in the consumer if the work should only happen once.
+   */
+  onChannelReady?: () => void;
+
   /** Custom header renderer. When provided, replaces the default header entirely. */
   renderHeader?: () => ReactNode;
 
@@ -130,6 +141,7 @@ export const Chatbot = forwardRef(function Chatbot(props: ChatbotProps, ref: For
     onSseError,
     onBeforeSendMessage,
     onMessageSent,
+    onChannelReady,
     renderHeader,
     renderMenu,
     renderToolCallGroup,
@@ -308,6 +320,7 @@ export const Chatbot = forwardRef(function Chatbot(props: ChatbotProps, ref: For
             onSseError={onSseError}
             onBeforeSendMessage={onBeforeSendMessage}
             onMessageSent={onMessageSent}
+            onChannelReady={onChannelReady}
             botTypingPlaceholder={botTypingPlaceholder}
             inputPlaceholder={inputPlaceholder}
             enableUpload={enableUpload}

--- a/packages/react/src/context/asgard-service-context.tsx
+++ b/packages/react/src/context/asgard-service-context.tsx
@@ -112,6 +112,11 @@ export interface AsgardServiceContextProviderProps {
   onMessageSent?: () => void;
   /** Whether to automatically reset channel on mount. Defaults to true. */
   autoResetChannel?: boolean;
+  /**
+   * Fired once the chat channel is ready to accept messages. Re-fires after
+   * channel reset.
+   */
+  onChannelReady?: () => void;
 }
 
 export function AsgardServiceContextProvider(props: AsgardServiceContextProviderProps): ReactNode {
@@ -134,6 +139,7 @@ export function AsgardServiceContextProvider(props: AsgardServiceContextProvider
     onBeforeSendMessage,
     onMessageSent,
     autoResetChannel,
+    onChannelReady,
   } = props;
 
   const messageBoxBottomRef = useRef<HTMLDivElement>(null);
@@ -196,6 +202,7 @@ export function AsgardServiceContextProvider(props: AsgardServiceContextProvider
     onAuthError,
     onSseError,
     onBeforeSendMessage,
+    onChannelReady,
   });
 
   const wrappedSendMessage: UseChannelReturn['sendMessage'] = useMemo(() => {

--- a/packages/react/src/hooks/use-channel.ts
+++ b/packages/react/src/hooks/use-channel.ts
@@ -9,7 +9,7 @@ import {
   SseResponse,
   ToolCallConsentAnswer,
 } from '@asgard-js/core';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export interface UseChannelProps {
   defaultIsOpen?: boolean;
@@ -31,6 +31,16 @@ export interface UseChannelProps {
     text: string;
     payload?: Record<string, unknown> | (() => Record<string, unknown>);
   }) => { text: string; payload?: Record<string, unknown> | (() => Record<string, unknown>) };
+  /**
+   * Fired once the chat channel is ready to accept messages. Triggered after
+   * the underlying Channel instance is created and the imperative ref has
+   * been updated, which guarantees calling
+   * `ref.current.serviceContext.sendMessage` from inside the callback works.
+   *
+   * Re-fires when the channel is replaced (e.g. after `resetChannel`). Use a
+   * guard ref in the consumer if the work should only happen once.
+   */
+  onChannelReady?: () => void;
 }
 
 export interface UseChannelReturn {
@@ -60,6 +70,7 @@ export function useChannel(props: UseChannelProps): UseChannelReturn {
     onAuthError,
     onSseError,
     onBeforeSendMessage,
+    onChannelReady,
   } = props;
 
   // Preview mode: client is null (when botProviderEndpoint is 'skip')
@@ -243,6 +254,16 @@ export function useChannel(props: UseChannelProps): UseChannelReturn {
       }
     }
   }, [isPreviewMode, channel, isOpen, autoResetChannel, resetChannel, initChannel, resetPayload]);
+
+  const prevChannelRef = useRef<Channel | null>(null);
+  useEffect(() => {
+    if (channel && channel !== prevChannelRef.current) {
+      prevChannelRef.current = channel;
+      onChannelReady?.();
+    } else if (!channel) {
+      prevChannelRef.current = null;
+    }
+  }, [channel, onChannelReady]);
 
   useEffect(() => {
     return (): void => closeChannel();


### PR DESCRIPTION
## Summary
- 新增 `onChannelReady` callback prop，channel 建立完成、ref 更新後觸發一次
- 解決上層需要等 channel ready 才能 `sendMessage` 的時機問題（取代 polling hack）
- channel 被替換（reset）時重新觸發；上層需要單次行為時可用 ref guard
- 新增 react-demo 的 `/on-channel-ready` 路由作為驗證頁
- 更新 `packages/react/README.md` 加入 prop 條目與 On Channel Ready section

## ClickUp
- [[SDK]需要支援客製化 button](https://app.clickup.com/t/86exevuap)

## Test plan
- [x] react-demo 加入 `onChannelReady`，驗證 mount 後正確 fire 一次
- [x] 驗證 fire 時 `ref.current.serviceContext.sendMessage` 為綁到新 channel 的可用版本
- [x] 驗證 channel 重新建立（remount）後重新 fire
- [x] 從 callback 內呼叫 `sendMessage` 訊息確實送出且 bot 回應
- [ ] Data Insight 整合驗證（用 callback 取代現有 100ms polling hack，確認 `initialText` 能穩定送出）

## Note
- 兩條 channel 建立路徑行為一致：`initChannel`（autoResetChannel: false，同步）與 `resetChannel`（autoResetChannel: true，await SSE）最終都觸發 `setChannel`，callback 統一在那一刻 fire
- 時序根據：`useImperativeHandle` 是 layout effect，跑在新加的 `useEffect` 之前，所以 callback 觸發時 ref 已更新 — 經 react-demo 驗證 `sendMessageAvailable: true` 與 `serviceContextAvailable: true` 在 mount / remount 場景皆成立