### PR TITLE
feat: add renderFooter prop to Chatbot

### DIFF
--- a/apps/react-demo/src/app/app.tsx
+++ b/apps/react-demo/src/app/app.tsx
@@ -21,6 +21,7 @@ import { ToolCallDemo } from './routes/tool-call';
 import { ToolCallConsentDemo } from './routes/tool-call-consent';
 import { UserIdentityHint } from './routes/user-identity-hint';
 import { OnChannelReady } from './routes/on-channel-ready';
+import { RenderFooter } from './routes/render-footer';
 
 export function App(): React.ReactElement {
   return (
@@ -47,6 +48,7 @@ export function App(): React.ReactElement {
         <Route path="/tool-call-consent" element={<ToolCallConsentDemo />} />
         <Route path="/user-identity-hint" element={<UserIdentityHint />} />
         <Route path="/on-channel-ready" element={<OnChannelReady />} />
+        <Route path="/render-footer" element={<RenderFooter />} />
       </Routes>
     </Layout>
   );

--- a/apps/react-demo/src/app/components/layout/layout.tsx
+++ b/apps/react-demo/src/app/components/layout/layout.tsx
@@ -21,6 +21,7 @@ const navItems = [
   { to: '/custom-header', label: 'Custom Header' },
   { to: '/auto-reset-channel', label: 'Auto Reset Channel' },
   { to: '/render-menu', label: 'Render Menu' },
+  { to: '/render-footer', label: 'Render Footer' },
   { to: '/http-error', label: 'HTTP Error' },
   { to: '/http-error-on-send', label: 'HTTP Error on Send' },
   { to: '/tool-call', label: 'Tool Call' },

--- a/apps/react-demo/src/app/routes/render-footer/index.ts
+++ b/apps/react-demo/src/app/routes/render-footer/index.ts
@@ -1,0 +1,1 @@
+export * from './render-footer';

--- a/apps/react-demo/src/app/routes/render-footer/render-footer.module.scss
+++ b/apps/react-demo/src/app/routes/render-footer/render-footer.module.scss
@@ -1,0 +1,70 @@
+.chatbotContainer {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+
+  > div {
+    width: 100%;
+    max-width: 420px;
+    height: 600px;
+  }
+}
+
+.footer {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid #434343;
+  background: #1a1a1a;
+}
+
+.textarea {
+  flex: 1;
+  min-height: 36px;
+  max-height: 120px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid #434343;
+  background: #2a2a2a;
+  color: white;
+  font-family: inherit;
+  font-size: 14px;
+  resize: none;
+  outline: none;
+
+  &:focus {
+    border-color: #6366f1;
+  }
+}
+
+.iconButton,
+.sendButton {
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.iconButton {
+  background: transparent;
+  color: white;
+  border: 1px solid #434343;
+}
+
+.sendButton {
+  background: #6366f1;
+  color: white;
+}

--- a/apps/react-demo/src/app/routes/render-footer/render-footer.tsx
+++ b/apps/react-demo/src/app/routes/render-footer/render-footer.tsx
@@ -1,0 +1,97 @@
+import { ChangeEvent, KeyboardEvent, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { Chatbot, useAsgardContext } from '@asgard-js/react';
+import '@asgard-js/react/style';
+import { DemoWrapper } from '../../components/demo-wrapper';
+import styles from './render-footer.module.scss';
+
+function CustomFooter(): ReactNode {
+  const { sendMessage, isConnecting, pendingInputValue, setPendingInputValue } = useAsgardContext();
+  const [value, setValue] = useState('');
+  const [isComposing, setIsComposing] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (pendingInputValue === null) return;
+
+    setValue(pendingInputValue);
+    setPendingInputValue(null);
+    textareaRef.current?.focus();
+  }, [pendingInputValue, setPendingInputValue]);
+
+  const isPreviewMode = !sendMessage;
+  const trimmed = value.trim();
+  const disabled = isPreviewMode || isConnecting || !trimmed;
+
+  const submit = useCallback((): void => {
+    if (disabled) return;
+
+    sendMessage?.({ text: trimmed });
+    setValue('');
+  }, [disabled, sendMessage, trimmed]);
+
+  const onChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>): void => {
+    setValue(event.target.value);
+  }, []);
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>): void => {
+      if (event.key === 'Enter' && !event.shiftKey && !isComposing) {
+        event.preventDefault();
+        submit();
+      }
+    },
+    [isComposing, submit],
+  );
+
+  const insertGreeting = useCallback((): void => {
+    setValue(prev => (prev ? prev : 'Hi there!'));
+    textareaRef.current?.focus();
+  }, []);
+
+  return (
+    <div className={styles.footer}>
+      <button
+        type="button"
+        className={styles.iconButton}
+        onClick={insertGreeting}
+        title="Insert a greeting"
+        disabled={isPreviewMode}
+      >
+        Hi
+      </button>
+      <textarea
+        ref={textareaRef}
+        className={styles.textarea}
+        rows={1}
+        value={value}
+        placeholder={isPreviewMode ? 'Preview mode - input disabled' : 'Type a message and press Enter'}
+        disabled={isPreviewMode}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        onCompositionStart={() => setIsComposing(true)}
+        onCompositionEnd={() => setIsComposing(false)}
+      />
+      <button type="button" className={styles.sendButton} onClick={submit} disabled={disabled}>
+        Send
+      </button>
+    </div>
+  );
+}
+
+export function RenderFooter(): ReactNode {
+  return (
+    <DemoWrapper
+      title="Render Footer"
+      description="Demonstrates renderFooter prop to fully replace the default footer. The custom footer uses useAsgardContext() to access sendMessage, isConnecting, and pendingInputValue."
+    >
+      <div className={styles.chatbotContainer}>
+        <Chatbot
+          title="Render Footer Demo"
+          config={{ botProviderEndpoint: import.meta.env.VITE_SIMPLE_BOT_PROVIDER_ENDPOINT }}
+          customChannelId="render-footer-demo"
+          renderFooter={() => <CustomFooter />}
+        />
+      </div>
+    </DemoWrapper>
+  );
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -318,6 +318,7 @@ config: {
 - **messageActions?**: `(message: ConversationBotMessage) => MessageActionConfig[]` - Function to define which action buttons to display for each bot message. Returns an array of `{ id: string, label: string }` objects. See [Message Actions](#message-actions) section for details.
 - **onMessageAction?**: `(actionId: string, message: ConversationBotMessage) => void` - Callback when a message action button is clicked. Receives the action ID and the associated bot message.
 - **renderHeader?**: `() => ReactNode` - Custom header renderer. When provided, completely replaces the default header. Use `useAsgardContext()` inside the render function to access `resetChannel`, `isResetting`, and other internal state.
+- **renderFooter?**: `() => ReactNode` - Custom footer renderer. When provided, completely replaces the default footer. Use `useAsgardContext()` inside the render function to access `sendMessage`, `isConnecting`, `pendingInputValue`, `setPendingInputValue`, etc. See [Custom Footer](#custom-footer) section for details.
 - **renderMenu?**: `() => ReactNode` - Custom menu renderer. When provided, renders content between the chat body and footer. Useful for quick menus, suggested questions, or navigation panels. See [Custom Menu](#custom-menu) section for details.
 - **renderMessageContent?**: `(props: MessageContentRendererProps) => ReactNode` - Custom renderer for message content. Allows customizing how messages are rendered based on message properties. See [Custom Message Renderer](#custom-message-renderer) section for details.
 - **renderToolCallGroup?**: `(props: ToolCallGroupRendererProps) => ReactNode` - Custom renderer for tool call group. Return `null` to hide, return JSX to fully customize, or call `renderDefaultContent()` to use the default UI with optional overrides (e.g., `renderDefaultContent({ title: 'AI is thinking...' })`). See [Tool Call Group Renderer](#tool-call-group-renderer) section for details.
@@ -1318,6 +1319,74 @@ const App = () => {
     />
   );
 };
+```
+
+<a id="custom-footer"></a>
+<br/>
+
+### Custom Footer
+
+The `renderFooter` prop allows you to completely replace the default chatbot footer with your own implementation. This is useful when the built-in input bar does not match your product's interaction pattern (e.g. fixed quick-reply buttons, custom send mechanics, or extra action buttons that cannot be expressed via `enableUpload` / `enableExport` / `enableDocumentUpload`).
+
+Use `useAsgardContext()` inside your custom footer to access `sendMessage`, `isConnecting`, `pendingInputValue`, `setPendingInputValue`, and other internal state. When `sendMessage` is `undefined`, the chatbot is in preview mode — disable input accordingly.
+
+#### Usage Example
+
+```typescript
+import { useEffect, useRef, useState } from 'react';
+import { Chatbot, useAsgardContext } from '@asgard-js/react';
+
+function CustomFooter() {
+  const { sendMessage, isConnecting, pendingInputValue, setPendingInputValue } = useAsgardContext();
+  const [value, setValue] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (pendingInputValue === null) return;
+
+    setValue(pendingInputValue);
+    setPendingInputValue(null);
+    textareaRef.current?.focus();
+  }, [pendingInputValue, setPendingInputValue]);
+
+  const isPreviewMode = !sendMessage;
+  const trimmed = value.trim();
+  const disabled = isPreviewMode || isConnecting || !trimmed;
+
+  const submit = () => {
+    if (disabled) return;
+
+    sendMessage?.({ text: trimmed });
+    setValue('');
+  };
+
+  return (
+    <div style={{ display: 'flex', gap: 8, padding: '12px 16px', borderTop: '1px solid #eee' }}>
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        disabled={isPreviewMode}
+        placeholder={isPreviewMode ? 'Preview mode' : 'Type a message'}
+        style={{ flex: 1 }}
+      />
+      <button onClick={submit} disabled={disabled}>
+        Send
+      </button>
+    </div>
+  );
+}
+
+const App = () => (
+  <Chatbot
+    config={{
+      apiKey: 'your-api-key',
+      botProviderEndpoint: 'https://api.asgard-ai.com/ns/{namespace}/bot-provider/{botProviderId}',
+    }}
+    customChannelId="your-channel-id"
+    renderFooter={() => <CustomFooter />}
+  />
+);
 ```
 
 <a id="custom-menu"></a>

--- a/packages/react/src/components/chatbot/chatbot.tsx
+++ b/packages/react/src/components/chatbot/chatbot.tsx
@@ -86,6 +86,14 @@ interface ChatbotProps extends AsgardTemplateContextValue {
   /** Custom header renderer. When provided, replaces the default header entirely. */
   renderHeader?: () => ReactNode;
 
+  /**
+   * Custom footer renderer. When provided, replaces the default footer
+   * entirely. Use `useAsgardContext()` inside the renderer to access
+   * `sendMessage`, `isConnecting`, `pendingInputValue`, `setPendingInputValue`,
+   * etc. Mirrors the pattern of `renderHeader`.
+   */
+  renderFooter?: () => ReactNode;
+
   /** Custom menu renderer. When provided, renders between chat body and footer. */
   renderMenu?: () => ReactNode;
 
@@ -143,6 +151,7 @@ export const Chatbot = forwardRef(function Chatbot(props: ChatbotProps, ref: For
     onMessageSent,
     onChannelReady,
     renderHeader,
+    renderFooter,
     renderMenu,
     renderToolCallGroup,
     autoResetChannel,
@@ -285,7 +294,7 @@ export const Chatbot = forwardRef(function Chatbot(props: ChatbotProps, ref: For
               <ChatbotBody />
             </AsgardTemplateContextProvider>
             {renderMenu?.()}
-            <ChatbotFooter />
+            {renderFooter ? renderFooter() : <ChatbotFooter />}
             <ToolCallConsentGate />
           </>
         );


### PR DESCRIPTION
## Summary
- 新增 `renderFooter` callback prop，傳入時整個取代內建 `<ChatbotFooter />`，與既有 `renderHeader` 對稱
- 上層在自製 footer 內透過 `useAsgardContext()` 取得 `sendMessage`、`isConnecting`、`pendingInputValue`、`setPendingInputValue` 等
- 不傳 `renderFooter` 時行為完全不變（內建 footer 維持原樣，含 upload / export / document / speech / drop-zone）
- 新增 react-demo 的 `/render-footer` 路由作為驗證頁
- 更新 `packages/react/README.md` 加入 prop 條目與 Custom Footer section

## ClickUp
- [[SDK]需要支援客製化 button](https://app.clickup.com/t/86exevuap)

## Test plan
- [x] react-demo `/render-footer` 自製 footer 正確取代內建 footer
- [x] textarea 透過 `pendingInputValue` 與 `setPendingInputValue` 雙向綁定可運作
- [x] Send button 呼叫 `sendMessage` 訊息確實送出且 bot 回應
- [x] `isConnecting` 為 true 時 send button disabled
- [x] 不傳 `renderFooter` 的其他 demo 頁，內建 footer 行為完全不變
- [ ] 上層應用整合驗證（待 SDK publish 後在 asgard-sdk-demo 端進一步驗證）

## Note
- 設計選擇：採「整個取代」派而非 slot，與 `renderHeader` / `renderMenu` 內部一致，並延續 PR #210 致敬 Sendbird UIKit（`renderMessageInput`）的設計路線
- 改動只動 `chatbot.tsx`，不動 `chatbot-footer.tsx` — 上層 100% 接管時內建 footer 整段直接不渲染
- 上層接管後內建的 upload / export / document / speech / drop-zone 不會出現，本次改動不提供「替換 footer 但保留內建按鈕」的混合模式（如未來有需求再考慮）