### PR TITLE
feat: add customFooterActions prop to Chatbot

### DIFF
--- a/apps/react-demo/src/app/app.tsx
+++ b/apps/react-demo/src/app/app.tsx
@@ -21,6 +21,7 @@ import { ToolCallDemo } from './routes/tool-call';
 import { ToolCallConsentDemo } from './routes/tool-call-consent';
 import { UserIdentityHint } from './routes/user-identity-hint';
 import { OnChannelReady } from './routes/on-channel-ready';
+import { CustomFooterActions } from './routes/custom-footer-actions';
 
 export function App(): React.ReactElement {
   return (
@@ -47,6 +48,7 @@ export function App(): React.ReactElement {
         <Route path="/tool-call-consent" element={<ToolCallConsentDemo />} />
         <Route path="/user-identity-hint" element={<UserIdentityHint />} />
         <Route path="/on-channel-ready" element={<OnChannelReady />} />
+        <Route path="/custom-footer-actions" element={<CustomFooterActions />} />
       </Routes>
     </Layout>
   );

--- a/apps/react-demo/src/app/components/layout/layout.tsx
+++ b/apps/react-demo/src/app/components/layout/layout.tsx
@@ -21,6 +21,7 @@ const navItems = [
   { to: '/custom-header', label: 'Custom Header' },
   { to: '/auto-reset-channel', label: 'Auto Reset Channel' },
   { to: '/render-menu', label: 'Render Menu' },
+  { to: '/custom-footer-actions', label: 'Custom Footer Actions' },
   { to: '/http-error', label: 'HTTP Error' },
   { to: '/http-error-on-send', label: 'HTTP Error on Send' },
   { to: '/tool-call', label: 'Tool Call' },

--- a/apps/react-demo/src/app/routes/custom-footer-actions/custom-footer-actions.module.scss
+++ b/apps/react-demo/src/app/routes/custom-footer-actions/custom-footer-actions.module.scss
@@ -1,0 +1,61 @@
+.chatbotContainer {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+
+  > div {
+    width: 100%;
+    max-width: 420px;
+    height: 600px;
+  }
+}
+
+.customAction {
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  border: 1px solid #434343;
+  background: transparent;
+  color: white;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 0 10px;
+  white-space: nowrap;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+}
+
+.controls {
+  margin-top: 16px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  color: white;
+  font-family: monospace;
+  font-size: 12px;
+}
+
+.controls h4 {
+  margin: 0 0 8px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.event {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 0;
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.1);
+}
+
+.event:last-child {
+  border-bottom: none;
+}

--- a/apps/react-demo/src/app/routes/custom-footer-actions/custom-footer-actions.tsx
+++ b/apps/react-demo/src/app/routes/custom-footer-actions/custom-footer-actions.tsx
@@ -1,0 +1,59 @@
+import { ReactNode, useCallback, useState } from 'react';
+import { Chatbot } from '@asgard-js/react';
+import '@asgard-js/react/style';
+import { DemoWrapper } from '../../components/demo-wrapper';
+import { createTextTemplateExample } from '../../mocks/messages';
+import styles from './custom-footer-actions.module.scss';
+
+interface ActionEvent {
+  at: string;
+  label: string;
+}
+
+export function CustomFooterActions(): ReactNode {
+  const [events, setEvents] = useState<ActionEvent[]>([]);
+  const initMessages = [createTextTemplateExample()];
+
+  const log = useCallback((label: string): void => {
+    setEvents(prev => [{ at: new Date().toLocaleTimeString(), label }, ...prev].slice(0, 8));
+  }, []);
+
+  const customFooterActions = [
+    <button key="export" className={styles.customAction} title="Export PDF" onClick={() => log('Export PDF')}>
+      PDF
+    </button>,
+    <button key="bookmark" className={styles.customAction} title="Bookmark" onClick={() => log('Bookmark')}>
+      Bm
+    </button>,
+  ];
+
+  return (
+    <DemoWrapper
+      title="Custom Footer Actions"
+      description="Demonstrates customFooterActions prop. Items render alongside built-in attachment buttons; the rest of the footer (textarea / send / mic) is unchanged."
+    >
+      <div className={styles.chatbotContainer}>
+        <Chatbot
+          title="Custom Footer Actions Demo"
+          config={{ botProviderEndpoint: 'skip' }}
+          customChannelId="custom-footer-actions-demo"
+          initMessages={initMessages}
+          customFooterActions={customFooterActions}
+        />
+      </div>
+      <div className={styles.controls}>
+        <h4>Action click log</h4>
+        {events.length === 0 ? (
+          <div>Click an action button above to log here.</div>
+        ) : (
+          events.map((e, idx) => (
+            <div key={idx} className={styles.event}>
+              <span>{e.label}</span>
+              <span>{e.at}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </DemoWrapper>
+  );
+}

--- a/apps/react-demo/src/app/routes/custom-footer-actions/index.ts
+++ b/apps/react-demo/src/app/routes/custom-footer-actions/index.ts
@@ -1,0 +1,1 @@
+export * from './custom-footer-actions';

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -292,7 +292,7 @@ config: {
   - `onRunDone?`: `DoneEventHandler` - Handler for run completion events
   - `onRunError?`: `ErrorEventHandler` - Error handler for execution errors
 - **customActions?**: `ReactNode[]` - Custom actions to display on the chatbot header
-- **customFooterActions?**: `ReactNode[]` - Custom action buttons rendered alongside the built-in footer attachment buttons (upload / export / document). Each item is a `ReactNode` and the consumer controls styling. Mirrors the pattern of `customActions`.
+- **customFooterActions?**: `ReactNode[]` - Custom action buttons rendered alongside the built-in footer attachment buttons (upload / export / document). Each item is a `ReactNode`; the consumer controls styling. Mirrors the pattern of `customActions`. See [Custom Footer Actions](#custom-footer-actions) section for details.
 - **enableLoadConfigFromService?**: `boolean` - Enable loading configuration from service
 - **enableUpload?**: `boolean` - Enable file upload functionality. When set, it takes priority over the `embedConfig.enableUpload` setting from the bot provider metadata. Defaults to `false` if not specified in either location. Supports image files (JPEG, PNG, GIF, WebP) up to 20MB per file, maximum 10 files at once.
 - **enableExport?**: `boolean` - Enable conversation export functionality. When set, it takes priority over the `embedConfig.enableExport` setting from the bot provider metadata. Defaults to `false` if not specified in either location. Adds a download button to the chatbot footer that exports the conversation history as a Markdown file with timestamps and trace IDs.
@@ -1320,6 +1320,52 @@ const App = () => {
   );
 };
 ```
+
+<a id="custom-footer-actions"></a>
+<br/>
+
+### Custom Footer Actions
+
+The `customFooterActions` prop adds extra buttons to the built-in footer alongside the default attachment buttons (upload / export / document). The rest of the footer — textarea, IME composition handling, send button, mic button, drag-and-drop — stays untouched. This is the right tool for the common "I just want to add a button" case; if you need to fully replace the footer, that requires a different (not-yet-shipped) prop.
+
+Items are plain `ReactNode`s; the consumer styles each button as they like.
+
+#### Usage Example
+
+```typescript
+import { Chatbot } from '@asgard-js/react';
+
+const App = () => {
+  const handleExportPdf = (): void => {
+    // ...
+  };
+
+  return (
+    <Chatbot
+      config={{
+        apiKey: 'your-api-key',
+        botProviderEndpoint: 'https://api.asgard-ai.com/ns/{namespace}/bot-provider/{botProviderId}',
+      }}
+      customChannelId="your-channel-id"
+      customFooterActions={[
+        <button key="pdf" onClick={handleExportPdf} title="Export PDF">
+          📄
+        </button>,
+        <button key="bookmark" onClick={() => console.log('Bookmark')} title="Bookmark">
+          🔖
+        </button>,
+      ]}
+    />
+  );
+};
+```
+
+#### Notes
+
+- Items render in the same row as the built-in attachment buttons (after upload / export / document, before the textarea).
+- They do **not** participate in the built-in collapse-into-`+`-menu logic; they always render inline. Avoid passing many items, or the row may overflow.
+- When the chatbot is in preview mode (`sendMessage` unavailable) the built-in buttons remain visible but inert. Your custom buttons stay clickable — disable them yourself if that matters.
+- For the rare case where you need a completely different input UX (e.g. structured form, code editor), this prop is not enough; use `useAsgardContext()` to read SDK state and build something on the side, or open an issue for a `renderFooter` escape hatch.
 
 <a id="custom-menu"></a>
 <br/>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -292,6 +292,7 @@ config: {
   - `onRunDone?`: `DoneEventHandler` - Handler for run completion events
   - `onRunError?`: `ErrorEventHandler` - Error handler for execution errors
 - **customActions?**: `ReactNode[]` - Custom actions to display on the chatbot header
+- **customFooterActions?**: `ReactNode[]` - Custom action buttons rendered alongside the built-in footer attachment buttons (upload / export / document). Each item is a `ReactNode` and the consumer controls styling. Mirrors the pattern of `customActions`.
 - **enableLoadConfigFromService?**: `boolean` - Enable loading configuration from service
 - **enableUpload?**: `boolean` - Enable file upload functionality. When set, it takes priority over the `embedConfig.enableUpload` setting from the bot provider metadata. Defaults to `false` if not specified in either location. Supports image files (JPEG, PNG, GIF, WebP) up to 20MB per file, maximum 10 files at once.
 - **enableExport?**: `boolean` - Enable conversation export functionality. When set, it takes priority over the `embedConfig.enableExport` setting from the bot provider metadata. Defaults to `false` if not specified in either location. Adds a download button to the chatbot footer that exports the conversation history as a Markdown file with timestamps and trace IDs.

--- a/packages/react/src/components/chatbot/chatbot-footer/chatbot-footer.tsx
+++ b/packages/react/src/components/chatbot/chatbot-footer/chatbot-footer.tsx
@@ -33,7 +33,11 @@ import {
 const MAX_IMAGE_COUNT = 10;
 const MAX_DOCUMENT_COUNT = 10;
 
-export function ChatbotFooter(): ReactNode {
+interface ChatbotFooterProps {
+  customFooterActions?: ReactNode[];
+}
+
+export function ChatbotFooter({ customFooterActions }: ChatbotFooterProps = {}): ReactNode {
   const {
     sendMessage,
     isConnecting,
@@ -851,6 +855,7 @@ export function ChatbotFooter(): ReactNode {
               )}
             </>
           )}
+          {customFooterActions}
         </div>
         <textarea
           ref={textareaRef}

--- a/packages/react/src/components/chatbot/chatbot.tsx
+++ b/packages/react/src/components/chatbot/chatbot.tsx
@@ -86,6 +86,13 @@ interface ChatbotProps extends AsgardTemplateContextValue {
   /** Custom header renderer. When provided, replaces the default header entirely. */
   renderHeader?: () => ReactNode;
 
+  /**
+   * Custom action buttons rendered alongside the built-in footer buttons
+   * (upload / export / document). Each item is a ReactNode and the consumer
+   * controls styling. Mirrors the pattern of `customActions` (header).
+   */
+  customFooterActions?: ReactNode[];
+
   /** Custom menu renderer. When provided, renders between chat body and footer. */
   renderMenu?: () => ReactNode;
 
@@ -143,6 +150,7 @@ export const Chatbot = forwardRef(function Chatbot(props: ChatbotProps, ref: For
     onMessageSent,
     onChannelReady,
     renderHeader,
+    customFooterActions,
     renderMenu,
     renderToolCallGroup,
     autoResetChannel,
@@ -285,7 +293,7 @@ export const Chatbot = forwardRef(function Chatbot(props: ChatbotProps, ref: For
               <ChatbotBody />
             </AsgardTemplateContextProvider>
             {renderMenu?.()}
-            <ChatbotFooter />
+            <ChatbotFooter customFooterActions={customFooterActions} />
             <ToolCallConsentGate />
           </>
         );


### PR DESCRIPTION
## Summary
- 新增 `customFooterActions: ReactNode[]` prop，渲染在內建 footer attachment buttons 之後（textarea 左側），與 header 既有的 `customActions` 對稱
- consumer 提供 ReactNode 陣列、自由 styling，純加法 slot，不影響內建 textarea / 上傳 / 麥克風 / 送出
- 不傳 `customFooterActions` 時行為完全不變
- 新增 react-demo 的 \`/custom-footer-actions\` 路由，示範兩顆 action button + click 紀錄
- 更新 \`packages/react/README.md\` 加入 prop 條目

## ClickUp
- [[SDK]需要支援客製化 button](https://app.clickup.com/t/86exevuap)

## 為什麼是 \`customFooterActions\` 而不是 \`renderFooter\`
ticket 標題明寫「客製化 **button**」，需求是「**加按鈕**」不是「換整個 footer」。`renderFooter` 雖然彈性，但會強迫 consumer 重做我們內建 footer 的 ~900 行邏輯（IME guard、auto-resize、drag-drop、image preview、document upload、speech、export……）才能加一顆按鈕，是斷崖不是彈性。

`customFooterActions` 是 confirmed 90% 場景的純加法解。`renderFooter` 留給未來真有 consumer 要全自製 footer 時再 ship（純加法、不 breaking）。設計討論完整紀錄在 `spec/custom-footer-actions.md`（gitignored）。

PR #243（`renderFooter`）暫不 merge，等真實需求出現再 promote。

## Test plan
- [x] react-demo \`/custom-footer-actions\` 自製 PDF / Bookmark 按鈕跟內建 attachment buttons 同排顯示
- [x] 點 PDF / Bookmark 觸發 onClick、上層 state 更新（log 顯示 timestamp）
- [x] 不傳 \`customFooterActions\` 的其他 demo 頁（如 \`/features\`），內建 footer 行為完全不變
- [x] 內建 textarea / 送出 / 麥克風行為不變
- [x] \`npm run lint:packages\` 通過
- [x] \`npm run build:react\` 通過
- [ ] 上層應用整合驗證（待 SDK publish 後在 asgard-sdk-demo 端進一步驗證）

## Note
- 形狀對齊既有 \`customActions\`（header）：純 \`ReactNode[]\`，consumer 控制 styling
- 渲染位置：內建 attachment buttons 同 div 之後（同樣 flex gap、同樣 grid column），不破壞既有 layout
- 不參與 attachment 折疊邏輯（>=3 的折疊只算內建 upload/export/document）
- 加太多 actions 視覺爆版是 consumer 自己的問題（同 header \`customActions\` 行為）