### PR TITLE
feat: add footerEndActions prop to Chatbot

### DIFF
--- a/apps/react-demo/src/app/app.tsx
+++ b/apps/react-demo/src/app/app.tsx
@@ -21,6 +21,7 @@ import { ToolCallDemo } from './routes/tool-call';
 import { ToolCallConsentDemo } from './routes/tool-call-consent';
 import { UserIdentityHint } from './routes/user-identity-hint';
 import { OnChannelReady } from './routes/on-channel-ready';
+import { FooterEndActions } from './routes/footer-end-actions';
 
 export function App(): React.ReactElement {
   return (
@@ -47,6 +48,7 @@ export function App(): React.ReactElement {
         <Route path="/tool-call-consent" element={<ToolCallConsentDemo />} />
         <Route path="/user-identity-hint" element={<UserIdentityHint />} />
         <Route path="/on-channel-ready" element={<OnChannelReady />} />
+        <Route path="/footer-end-actions" element={<FooterEndActions />} />
       </Routes>
     </Layout>
   );

--- a/apps/react-demo/src/app/components/layout/layout.tsx
+++ b/apps/react-demo/src/app/components/layout/layout.tsx
@@ -21,6 +21,7 @@ const navItems = [
   { to: '/custom-header', label: 'Custom Header' },
   { to: '/auto-reset-channel', label: 'Auto Reset Channel' },
   { to: '/render-menu', label: 'Render Menu' },
+  { to: '/footer-end-actions', label: 'Footer End Actions' },
   { to: '/http-error', label: 'HTTP Error' },
   { to: '/http-error-on-send', label: 'HTTP Error on Send' },
   { to: '/tool-call', label: 'Tool Call' },

--- a/apps/react-demo/src/app/routes/footer-end-actions/footer-end-actions.module.scss
+++ b/apps/react-demo/src/app/routes/footer-end-actions/footer-end-actions.module.scss
@@ -1,0 +1,108 @@
+.chatbotContainer {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+
+  > div {
+    width: 100%;
+    max-width: 480px;
+    height: 600px;
+  }
+}
+
+.endActionButton {
+  height: 36px;
+  min-width: 36px;
+  padding: 0 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+  }
+}
+
+.modalBackdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  width: 90%;
+  max-width: 600px;
+  background: #1f1f1f;
+  border: 1px solid #434343;
+  border-radius: 8px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.modalTitle {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: white;
+}
+
+.modalTextarea {
+  min-height: 200px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  border: 1px solid #434343;
+  background: #111;
+  color: #d4d4d4;
+  font-family: 'JetBrains Mono', Menlo, monospace;
+  font-size: 13px;
+  resize: vertical;
+  outline: none;
+
+  &:focus {
+    border-color: #6366f1;
+  }
+}
+
+.modalActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.modalCancel,
+.modalSubmit {
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.modalCancel {
+  background: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  border: 1px solid #434343;
+}
+
+.modalSubmit {
+  background: #6366f1;
+  color: white;
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}

--- a/apps/react-demo/src/app/routes/footer-end-actions/footer-end-actions.tsx
+++ b/apps/react-demo/src/app/routes/footer-end-actions/footer-end-actions.tsx
@@ -1,0 +1,77 @@
+import { ChangeEvent, ReactNode, useCallback, useRef, useState } from 'react';
+import { Chatbot, ChatbotRef } from '@asgard-js/react';
+import '@asgard-js/react/style';
+import { DemoWrapper } from '../../components/demo-wrapper';
+import styles from './footer-end-actions.module.scss';
+
+const INITIAL_SQL = `SELECT *
+FROM orders
+WHERE created_at >= NOW() - INTERVAL '7 days'
+ORDER BY created_at DESC
+LIMIT 100;`;
+
+export function FooterEndActions(): ReactNode {
+  const chatbotRef = useRef<ChatbotRef>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [sql, setSql] = useState(INITIAL_SQL);
+
+  const openModal = useCallback((): void => {
+    setIsModalOpen(true);
+  }, []);
+
+  const closeModal = useCallback((): void => {
+    setIsModalOpen(false);
+  }, []);
+
+  const onSqlChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>): void => {
+    setSql(event.target.value);
+  }, []);
+
+  const submitSql = useCallback((): void => {
+    const text = sql.trim();
+    if (!text) return;
+
+    chatbotRef.current?.serviceContext?.sendMessage?.({ text });
+    setIsModalOpen(false);
+  }, [sql]);
+
+  const footerEndActions: ReactNode[] = [
+    <button key="sql" type="button" className={styles.endActionButton} onClick={openModal} title="Open SQL editor">
+      SQL
+    </button>,
+  ];
+
+  return (
+    <DemoWrapper
+      title="Footer End Actions"
+      description="Demonstrates footerEndActions prop. The 'SQL' button at the end of the footer opens a modal SQL editor; submitting the modal calls sendMessage via ref. Mirrors Data Insight's real use case (replacing the cramped textarea with a full-screen editor for SQL writing)."
+    >
+      <div className={styles.chatbotContainer}>
+        <Chatbot
+          ref={chatbotRef}
+          title="Footer End Actions Demo"
+          config={{ botProviderEndpoint: import.meta.env.VITE_SIMPLE_BOT_PROVIDER_ENDPOINT }}
+          customChannelId="footer-end-actions-demo"
+          footerEndActions={footerEndActions}
+        />
+      </div>
+
+      {isModalOpen && (
+        <div className={styles.modalBackdrop} onClick={closeModal}>
+          <div className={styles.modal} onClick={e => e.stopPropagation()}>
+            <h3 className={styles.modalTitle}>SQL Editor</h3>
+            <textarea className={styles.modalTextarea} value={sql} onChange={onSqlChange} spellCheck={false} />
+            <div className={styles.modalActions}>
+              <button type="button" className={styles.modalCancel} onClick={closeModal}>
+                Cancel
+              </button>
+              <button type="button" className={styles.modalSubmit} onClick={submitSql} disabled={!sql.trim()}>
+                Submit
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </DemoWrapper>
+  );
+}

--- a/apps/react-demo/src/app/routes/footer-end-actions/index.ts
+++ b/apps/react-demo/src/app/routes/footer-end-actions/index.ts
@@ -1,0 +1,1 @@
+export * from './footer-end-actions';

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -319,6 +319,7 @@ config: {
 - **onMessageAction?**: `(actionId: string, message: ConversationBotMessage) => void` - Callback when a message action button is clicked. Receives the action ID and the associated bot message.
 - **renderHeader?**: `() => ReactNode` - Custom header renderer. When provided, completely replaces the default header. Use `useAsgardContext()` inside the render function to access `resetChannel`, `isResetting`, and other internal state.
 - **renderMenu?**: `() => ReactNode` - Custom menu renderer. When provided, renders content between the chat body and footer. Useful for quick menus, suggested questions, or navigation panels. See [Custom Menu](#custom-menu) section for details.
+- **footerEndActions?**: `ReactNode[]` - Extra action nodes rendered at the end of the footer input row, after the send/mic button. Pure additive slot — built-in textarea / attachment buttons / send / mic remain unchanged. See [Footer End Actions](#footer-end-actions) section for details.
 - **renderMessageContent?**: `(props: MessageContentRendererProps) => ReactNode` - Custom renderer for message content. Allows customizing how messages are rendered based on message properties. See [Custom Message Renderer](#custom-message-renderer) section for details.
 - **renderToolCallGroup?**: `(props: ToolCallGroupRendererProps) => ReactNode` - Custom renderer for tool call group. Return `null` to hide, return JSX to fully customize, or call `renderDefaultContent()` to use the default UI with optional overrides (e.g., `renderDefaultContent({ title: 'AI is thinking...' })`). See [Tool Call Group Renderer](#tool-call-group-renderer) section for details.
 - **onBeforeSendMessage?**: `(params: SendMessageParams) => SendMessageParams` - Callback to modify message params before sending. Allows injecting contextual data (payload, metadata) from parent components. See [Before Send Message Hook](#before-send-message-hook) section for details.
@@ -1319,6 +1320,62 @@ const App = () => {
   );
 };
 ```
+
+<a id="footer-end-actions"></a>
+<br/>
+
+### Footer End Actions
+
+The `footerEndActions` prop appends extra nodes at the **end of the footer input row**, after the send/mic button. Pure additive slot — the built-in textarea, attachment buttons, send button, mic button, drag-and-drop, IME composition guard, image preview, and document upload all stay untouched.
+
+Use this for actions that complement the send flow but aren't replacements for it — for example a button that opens a fullscreen SQL editor modal, a "switch to voice mode" toggle, or a settings popover.
+
+#### Usage Example
+
+```typescript
+import { useRef, useState } from 'react';
+import { Chatbot, ChatbotRef } from '@asgard-js/react';
+
+const App = () => {
+  const chatbotRef = useRef<ChatbotRef>(null);
+  const [editorOpen, setEditorOpen] = useState(false);
+
+  return (
+    <>
+      <Chatbot
+        ref={chatbotRef}
+        config={{
+          apiKey: 'your-api-key',
+          botProviderEndpoint: 'https://api.asgard-ai.com/ns/{namespace}/bot-provider/{botProviderId}',
+        }}
+        customChannelId="your-channel-id"
+        footerEndActions={[
+          <button key="sql" onClick={() => setEditorOpen(true)} title="Open SQL editor">
+            SQL
+          </button>,
+        ]}
+      />
+      {editorOpen && (
+        <SqlEditorModal
+          onSubmit={text => {
+            chatbotRef.current?.serviceContext?.sendMessage?.({ text });
+            setEditorOpen(false);
+          }}
+          onCancel={() => setEditorOpen(false)}
+        />
+      )}
+    </>
+  );
+};
+```
+
+#### Notes
+
+- Items render at the trailing end of the footer input row (after send/mic). They do **not** participate in the attachment-buttons collapse-into-`+`-menu logic on the leading side.
+- Each item is a plain `ReactNode`; the consumer fully controls styling. Match the height of the built-in send/mic button (~36px) so the row stays visually consistent.
+- Avoid passing many items — the row width is finite and overflow will squeeze the textarea.
+- Use `chatbotRef.current?.serviceContext?.sendMessage` (or `useAsgardContext()` inside a wrapper component) to send messages from the consumer-owned UI that the action triggers (e.g. modal Submit button).
+- Distinct from `customActions` (header trailing): `customActions` appends to the **header** title bar, `footerEndActions` appends to the **footer** input row.
 
 <a id="custom-menu"></a>
 <br/>

--- a/packages/react/src/components/chatbot/chatbot-footer/chatbot-footer.module.scss
+++ b/packages/react/src/components/chatbot/chatbot-footer/chatbot-footer.module.scss
@@ -85,6 +85,12 @@
   align-items: center;
 }
 
+.send_zone {
+  display: flex;
+  gap: var(--asg-spacing-2);
+  align-items: center;
+}
+
 .attachment_menu_container {
   position: relative;
 }

--- a/packages/react/src/components/chatbot/chatbot-footer/chatbot-footer.tsx
+++ b/packages/react/src/components/chatbot/chatbot-footer/chatbot-footer.tsx
@@ -33,7 +33,11 @@ import {
 const MAX_IMAGE_COUNT = 10;
 const MAX_DOCUMENT_COUNT = 10;
 
-export function ChatbotFooter(): ReactNode {
+interface ChatbotFooterProps {
+  footerEndActions?: ReactNode[];
+}
+
+export function ChatbotFooter({ footerEndActions }: ChatbotFooterProps = {}): ReactNode {
   const {
     sendMessage,
     isConnecting,
@@ -868,22 +872,25 @@ export function ChatbotFooter(): ReactNode {
           onCompositionStart={() => setIsComposing(true)}
           onCompositionEnd={() => setIsComposing(false)}
         />
-        {value || uploadableImages.length > 0 || uploadableDocuments.length > 0 ? (
-          <button
-            className={clsx(styles.chatbot_submit_button, disabled && styles.chatbot_submit_button__disabled)}
-            style={chatbot.footer?.submitButton?.style}
-            disabled={disabled}
-            onClick={onSubmit}
-          >
-            <SendSvg />
-          </button>
-        ) : (
-          <SpeechInputButton
-            setValue={setValue}
-            className={clsx(styles.chatbot_submit_button, isConnecting && styles.chatbot_submit_button__disabled)}
-            style={chatbot.footer?.speechInputButton?.style}
-          />
-        )}
+        <div className={styles.send_zone}>
+          {value || uploadableImages.length > 0 || uploadableDocuments.length > 0 ? (
+            <button
+              className={clsx(styles.chatbot_submit_button, disabled && styles.chatbot_submit_button__disabled)}
+              style={chatbot.footer?.submitButton?.style}
+              disabled={disabled}
+              onClick={onSubmit}
+            >
+              <SendSvg />
+            </button>
+          ) : (
+            <SpeechInputButton
+              setValue={setValue}
+              className={clsx(styles.chatbot_submit_button, isConnecting && styles.chatbot_submit_button__disabled)}
+              style={chatbot.footer?.speechInputButton?.style}
+            />
+          )}
+          {footerEndActions}
+        </div>
       </div>
 
       {previewImage && (

--- a/packages/react/src/components/chatbot/chatbot.tsx
+++ b/packages/react/src/components/chatbot/chatbot.tsx
@@ -89,6 +89,14 @@ interface ChatbotProps extends AsgardTemplateContextValue {
   /** Custom menu renderer. When provided, renders between chat body and footer. */
   renderMenu?: () => ReactNode;
 
+  /**
+   * Extra action nodes rendered at the end of the footer input row, after the
+   * send/mic button. Pure additive slot — built-in textarea / attachment
+   * buttons / send / mic remain unchanged. Use it to add buttons such as
+   * "open SQL editor modal", "switch input mode", etc.
+   */
+  footerEndActions?: ReactNode[];
+
   /** Custom renderer for tool call group. Return null to hide, or return custom JSX. */
   renderToolCallGroup?: AsgardTemplateContextValue['renderToolCallGroup'];
 
@@ -144,6 +152,7 @@ export const Chatbot = forwardRef(function Chatbot(props: ChatbotProps, ref: For
     onChannelReady,
     renderHeader,
     renderMenu,
+    footerEndActions,
     renderToolCallGroup,
     autoResetChannel,
     userIdentityHint,
@@ -285,7 +294,7 @@ export const Chatbot = forwardRef(function Chatbot(props: ChatbotProps, ref: For
               <ChatbotBody />
             </AsgardTemplateContextProvider>
             {renderMenu?.()}
-            <ChatbotFooter />
+            <ChatbotFooter footerEndActions={footerEndActions} />
             <ToolCallConsentGate />
           </>
         );


### PR DESCRIPTION
## Summary
- 新增 `footerEndActions: ReactNode[]` prop，傳入的節點渲染在 footer input row 的**最右邊**（send/mic button 之後）
- 純加法 slot：textarea / 附件按鈕 / send / mic / IME guard / drag-drop / image preview / document upload 等內建邏輯**完全保留**
- 用途範例：打開 SQL editor modal、切換輸入模式、設定 popover 等「補充 send 流程」的次要動作
- 修正 layout：原本 footer 是 CSS Grid 3 欄（attachment / textarea / send-or-mic），多塞 child 會 wrap 到下一 row。把 send/mic + footerEndActions 包進新的 \`.send_zone\` flex 容器，仍佔第 3 grid cell，layout 不會跑掉
- 新增 react-demo \`/footer-end-actions\` 路由：示範 Data Insight 真實 use case — 點 SQL 按鈕開 modal SQL editor、Submit 透過 \`chatbotRef.current.serviceContext.sendMessage\` 送出
- 更新 \`packages/react/README.md\` 加入 prop 條目與 Footer End Actions section

## ClickUp
- [[SDK]需要支援客製化 button](https://app.clickup.com/t/86exevuap)
- [[Data Insight] Copy as new insight 沒有作用](https://app.clickup.com/t/86exe9wwd) — Jim 在 thread 裡確認需求是「打開 SQL editor modal 的按鈕」

## 為什麼是 \`footerEndActions\` 而不是其他名稱
- \`customFooterActions\` → \`footer\` 太大，沒指明位置（footer 內有 attachment / textarea / send 三個區域）
- 業界 input row slot 命名一律用「位置前綴」：Material UI \`endAdornment\` / \`startAdornment\`、Mantine \`leftSection\` / \`rightSection\`、Chakra \`leftElement\` / \`rightElement\`、Ant Design \`addonAfter\` / \`addonBefore\`
- \`footerEndActions\` 對齊業界 pattern，讀者一看就知道塞在哪。未來真的要左側 slot 就 \`footerStartActions\`，pattern 對稱

## 為什麼是 slot 派而不是 replace 派（\`renderFooter\`）
- ClickUp 票標題就是「客製化 button」，需求是加按鈕，不是換 footer
- 走 replace 會逼下游為了一顆按鈕重做 ~900 行內建邏輯
- slot 派純加法、可逆 — 未來真有 consumer 要全自製 footer 再加 \`renderFooter\` 是 non-breaking
- 業界 AI chatbot SDK（Stream / CometChat / Botpress）都走 slot 派；Sendbird 走 replace 派但他們是人對人 chat、input 詞彙穩定，跟我們情境不同

## Test plan
- [x] react-demo \`/footer-end-actions\` SQL 按鈕渲染在 send/mic 右邊，與 mic 同一 row
- [x] 點 SQL → 自製 SQL editor modal 開啟，textarea 預填 SQL
- [x] modal Submit → SQL 送進 chatbot、bot echo 回應、modal 關閉
- [x] 內建 textarea / 送出 / 麥克風行為完全不變
- [x] 不傳 \`footerEndActions\` 的其他 demo 頁（如 \`/features\`），內建 footer 行為完全不變
- [x] \`npm run lint:packages\` 通過
- [x] \`npm run build:react\` 通過
- [ ] 上層應用整合驗證（待 Data Insight 試裝 canary 並確認位置與 modal 觸發路徑符合需求）

## Note
- canary 已 publish：\`@asgard-js/{core,react}@0.2.40-canary.3\`（待 publish）
- 同一票的 \`renderFooter\` 方向（PR #243）已關閉、\`customFooterActions\` 方向（PR #244）已關閉，最終採此 PR 的 \`footerEndActions\` 方向