### PR TITLE
fix: send last user message id in consent reply

### DIFF
--- a/packages/core/src/lib/channel.ts
+++ b/packages/core/src/lib/channel.ts
@@ -24,6 +24,11 @@ export default class Channel {
   private statesObserver?: ObserverOrNext<ChannelStates>;
   private statesSubscription?: Subscription;
   private currentUserMessageId?: string;
+  // The most-recently-sent user message id. Unlike currentUserMessageId (which
+  // is cleared once a traceId is attached), this is kept across the SSE
+  // lifecycle so RESPONSE_TOOL_CALL_CONSENT — fired after run.done — can echo
+  // back the message id the bot is waiting on.
+  private lastSentMessageId?: string;
 
   private constructor(config: ChannelConfig) {
     if (!config.client) {
@@ -166,6 +171,7 @@ export default class Channel {
     const messageId = payload.customMessageId ?? uuidv4();
 
     this.currentUserMessageId = messageId;
+    this.lastSentMessageId = messageId;
 
     this.conversation$.next(
       this.conversation$.value.pushMessage({
@@ -199,7 +205,7 @@ export default class Channel {
       {
         action: FetchSseAction.RESPONSE_TOOL_CALL_CONSENT,
         customChannelId: this.customChannelId,
-        customMessageId: this.customMessageId,
+        customMessageId: this.lastSentMessageId ?? this.customMessageId,
         text: '',
         toolCallConsents,
       },


### PR DESCRIPTION
## Summary
- `Channel.replyToolCallConsents` 送出時 `customMessageId` 是 `undefined`，bot provider 退 `customMessageId is required`
- 根因：`this.customMessageId` 只在 constructor 設定一次；`this.currentUserMessageId` 在第一個帶 traceId 的 SSE event 之後就被清掉，使用者按 Allow/Deny 時已空
- 新增 `lastSentMessageId`：`sendMessage` 時設、不跟著 SSE 生命週期清，`replyToolCallConsents` 用它（fallback 到 `this.customMessageId` 保留向後相容）

## 觸發情境
- 任何沒在 Chatbot props 傳 `customMessageId`、且工作流會跳 consent 的 channel
- 實機 trace（asgard-auto-post）：bot 呼叫 `bash` / `str_replace_editor` → SSE 發 `asgard.tool_call.consent` → 使用者按 Allow for This Chat → POST `/message/sse`：
  ```json
  {
    "action": "RESPONSE_TOOL_CALL_CONSENT",
    "customChannelId": "…",
    "text": "",
    "toolCallConsents": [{"toolCallId": "…", "result": "ALLOW_ALWAYS", "denyReason": ""}]
  }
  ```
  缺 `customMessageId` 欄位 → 400

## Test plan
- [x] `npm run build:core` 通過
- [x] `npm run build:react` 通過
- [x] `npm run lint:packages` 通過
- [ ] 實機驗證：consent 送出後 `customMessageId` 帶最近一次 sendMessage 的 id，bot 接著 resume tool call（reviewer 用 react-demo 的 `/tool-call-consent` 頁面或 asgard-auto-post sandbox 驗）