### PR TITLE
feat: route consent reply through onBeforeSendMessage for payload

### DIFF
--- a/packages/core/src/lib/channel.ts
+++ b/packages/core/src/lib/channel.ts
@@ -210,9 +210,9 @@ export default class Channel {
         action: FetchSseAction.RESPONSE_TOOL_CALL_CONSENT,
         customChannelId: this.customChannelId,
         customMessageId: this.lastSentMessageId ?? this.customMessageId,
+        payload: this.resolvePayload(payload),
         text: '',
         toolCallConsents,
-        payload: this.resolvePayload(payload),
       },
       options,
     );

--- a/packages/core/src/lib/channel.ts
+++ b/packages/core/src/lib/channel.ts
@@ -198,7 +198,11 @@ export default class Channel {
     );
   }
 
-  public replyToolCallConsents(toolCallConsents: ToolCallConsentAnswer[], options?: FetchSseOptions): Promise<void> {
+  public replyToolCallConsents(
+    toolCallConsents: ToolCallConsentAnswer[],
+    options?: FetchSseOptions,
+    payload?: FetchSsePayload['payload'],
+  ): Promise<void> {
     this.conversation$.next(this.conversation$.value.clearPendingConsent());
 
     return this.fetchSse(
@@ -208,6 +212,7 @@ export default class Channel {
         customMessageId: this.lastSentMessageId ?? this.customMessageId,
         text: '',
         toolCallConsents,
+        payload: this.resolvePayload(payload),
       },
       options,
     );

--- a/packages/react/src/components/chatbot/chatbot.tsx
+++ b/packages/react/src/components/chatbot/chatbot.tsx
@@ -66,7 +66,13 @@ interface ChatbotProps extends AsgardTemplateContextValue {
   /** Callback fired when SSE connection encounters an error */
   onSseError?: (error: unknown) => void;
 
-  /** Callback to modify message params before sending */
+  /**
+   * Callback to modify outbound params before they hit the wire. Fires for
+   * both regular `sendMessage` and tool-call consent reply (Allow / Deny on
+   * the consent modal). For consent reply, `params.text` is always `''` and
+   * `params.blobIds` is `undefined` — only the resulting `payload` is
+   * forwarded; `text` / `blobIds` from the return are dropped on that path.
+   */
   onBeforeSendMessage?: (params: SendMessageParams) => SendMessageParams;
 
   /** Callback fired after a message has been sent */

--- a/packages/react/src/context/asgard-service-context.tsx
+++ b/packages/react/src/context/asgard-service-context.tsx
@@ -226,6 +226,21 @@ export function AsgardServiceContextProvider(props: AsgardServiceContextProvider
     };
   }, [sendMessage, onBeforeSendMessage, onMessageSent]);
 
+  // Consent reply runs through onBeforeSendMessage too, so consumers can use a
+  // single hook to attach session-level payload (e.g. interaction_mode) on
+  // every outbound. The callback is invoked with `text: ''` and no payload —
+  // only the resulting `payload` is forwarded; `text`/`blobIds` from the
+  // return are ignored on this path.
+  const wrappedReplyToolCallConsents: UseChannelReturn['replyToolCallConsents'] = useMemo(() => {
+    if (!replyToolCallConsents) return undefined;
+
+    return async answers => {
+      const resolved = onBeforeSendMessage ? onBeforeSendMessage({ text: '', payload: undefined }) : undefined;
+
+      return replyToolCallConsents(answers, resolved?.payload);
+    };
+  }, [replyToolCallConsents, onBeforeSendMessage]);
+
   const contextValue = useMemo(
     () => ({
       avatar,
@@ -239,7 +254,7 @@ export function AsgardServiceContextProvider(props: AsgardServiceContextProvider
       sendMessage: wrappedSendMessage,
       resetChannel,
       closeChannel,
-      replyToolCallConsents,
+      replyToolCallConsents: wrappedReplyToolCallConsents,
       pendingConsent: conversation?.pendingConsent ?? null,
       botTypingPlaceholder,
       inputPlaceholder,
@@ -268,7 +283,7 @@ export function AsgardServiceContextProvider(props: AsgardServiceContextProvider
       wrappedSendMessage,
       resetChannel,
       closeChannel,
-      replyToolCallConsents,
+      wrappedReplyToolCallConsents,
       botTypingPlaceholder,
       inputPlaceholder,
       enableUpload,

--- a/packages/react/src/context/asgard-service-context.tsx
+++ b/packages/react/src/context/asgard-service-context.tsx
@@ -106,7 +106,13 @@ export interface AsgardServiceContextProviderProps {
   onAuthError?: (error: { isAuthError: boolean; isBotProviderError: boolean; errorDetail?: unknown }) => void;
   /** Callback fired when SSE connection encounters an error */
   onSseError?: (error: unknown) => void;
-  /** Callback to modify message params before sending */
+  /**
+   * Callback to modify outbound params before they hit the wire. Fires for
+   * both regular `sendMessage` and tool-call consent reply (Allow / Deny on
+   * the consent modal). For consent reply, `params.text` is always `''` and
+   * `params.blobIds` is `undefined` — only the resulting `payload` is
+   * forwarded; `text` / `blobIds` from the return are dropped on that path.
+   */
   onBeforeSendMessage?: (params: SendMessageParams) => SendMessageParams;
   /** Callback fired after a message has been sent */
   onMessageSent?: () => void;
@@ -233,6 +239,14 @@ export function AsgardServiceContextProvider(props: AsgardServiceContextProvider
   // forwarded; `text`/`blobIds` from the return are ignored on this path.
   // Side effects inside the callback fire on this path too — branch on
   // intent (e.g. inspect `params.text === ''`) if they should not.
+  //
+  // Differences from `wrappedSendMessage`:
+  //   - No `onMessageSent` fire: consent reply isn't a user message, so the
+  //     sent-message lifecycle hook should not fire here.
+  //   - No try/catch swallow: the inner `replyToolCallConsents` does not yet
+  //     propagate `onSseError`/`onAuthError` (pre-existing gap), so the
+  //     promise rejection is the only error signal callers get — swallowing
+  //     it would drop errors entirely.
   const wrappedReplyToolCallConsents: UseChannelReturn['replyToolCallConsents'] = useMemo(() => {
     if (!replyToolCallConsents) return undefined;
 

--- a/packages/react/src/context/asgard-service-context.tsx
+++ b/packages/react/src/context/asgard-service-context.tsx
@@ -228,16 +228,18 @@ export function AsgardServiceContextProvider(props: AsgardServiceContextProvider
 
   // Consent reply runs through onBeforeSendMessage too, so consumers can use a
   // single hook to attach session-level payload (e.g. interaction_mode) on
-  // every outbound. The callback is invoked with `text: ''` and no payload —
-  // only the resulting `payload` is forwarded; `text`/`blobIds` from the
-  // return are ignored on this path.
+  // every outbound. The callback is invoked with `text: ''` and the
+  // caller-supplied payload (if any) — only the resulting `payload` is
+  // forwarded; `text`/`blobIds` from the return are ignored on this path.
+  // Side effects inside the callback fire on this path too — branch on
+  // intent (e.g. inspect `params.text === ''`) if they should not.
   const wrappedReplyToolCallConsents: UseChannelReturn['replyToolCallConsents'] = useMemo(() => {
     if (!replyToolCallConsents) return undefined;
 
-    return async answers => {
-      const resolved = onBeforeSendMessage ? onBeforeSendMessage({ text: '', payload: undefined }) : undefined;
+    return async (answers, payload) => {
+      const resolved = onBeforeSendMessage ? onBeforeSendMessage({ text: '', payload }) : { text: '', payload };
 
-      return replyToolCallConsents(answers, resolved?.payload);
+      return replyToolCallConsents(answers, resolved.payload);
     };
   }, [replyToolCallConsents, onBeforeSendMessage]);
 

--- a/packages/react/src/hooks/use-channel.ts
+++ b/packages/react/src/hooks/use-channel.ts
@@ -54,7 +54,7 @@ export interface UseChannelReturn {
   ) => Promise<void>;
   resetChannel?: (payload?: Pick<FetchSsePayload, 'text'> & Partial<Pick<FetchSsePayload, 'payload'>>) => void;
   closeChannel?: () => void;
-  replyToolCallConsents?: (answers: ToolCallConsentAnswer[]) => Promise<void>;
+  replyToolCallConsents?: (answers: ToolCallConsentAnswer[], payload?: FetchSsePayload['payload']) => Promise<void>;
 }
 
 export function useChannel(props: UseChannelProps): UseChannelReturn {
@@ -231,14 +231,18 @@ export function useChannel(props: UseChannelProps): UseChannelReturn {
   );
 
   const replyToolCallConsents = useCallback(
-    async (answers: ToolCallConsentAnswer[]): Promise<void> => {
-      await channel?.replyToolCallConsents(answers, {
-        onSseMessage(response: SseResponse<EventType>) {
-          onSseMessage?.(response, {
-            conversation,
-          });
+    async (answers: ToolCallConsentAnswer[], payload?: FetchSsePayload['payload']): Promise<void> => {
+      await channel?.replyToolCallConsents(
+        answers,
+        {
+          onSseMessage(response: SseResponse<EventType>) {
+            onSseMessage?.(response, {
+              conversation,
+            });
+          },
         },
-      });
+        payload,
+      );
     },
     [channel, onSseMessage, conversation],
   );


### PR DESCRIPTION
## 摘要
- Tool-call consent reply（`RESPONSE_TOOL_CALL_CONSENT`）原本不帶 payload 欄位，consumer 透過 `onBeforeSendMessage` 注入的 session-level metadata（例如 `interaction_mode`）在按 Allow / Deny 時會被丟掉。
- Heimdall workflow 因此用預設 mode resume，bot 回應行為跟使用者選的 PLAN / EDIT / FREE 不一致。
- 這個 PR 讓 `onBeforeSendMessage` 同時涵蓋 consent reply，consumer 用一個 hook 就能對所有 outbound 注入 payload。

## 改動
- **`Channel.replyToolCallConsents`**：新增 optional 第 3 個參數 `payload`，組進 `fetchSse` body，欄位排列跟 `sendMessage` 對齊。
- **`useChannel.replyToolCallConsents`**：簽名同步加 `payload`，往下傳。
- **`AsgardServiceContext`**：新增 `wrappedReplyToolCallConsents`，跟 `wrappedSendMessage` 對稱。
  - 用 `onBeforeSendMessage({ text: '', payload })` 呼叫 callback（caller 傳的 payload 也轉進去，callback 可以讀 / 改寫）。
  - 只採用 callback 回傳的 `payload`；`text` / `blobIds` 在這條 path 會被丟棄。
  - Inline comment 說明跟 `wrappedSendMessage` 為何有差（不 fire `onMessageSent`、不包 try/catch）。
- **`Chatbot` / `AsgardServiceContextProvider` 的 prop docstring**：`onBeforeSendMessage` 註解更新，明確說會兩條 path 都觸發、且 consent path 的 `params.text` 是 `''`。

## Wire-format 差異（consent reply request body）

修改前：
```json
{
  "action": "RESPONSE_TOOL_CALL_CONSENT",
  "customChannelId": "…",
  "customMessageId": "…",
  "text": "",
  "toolCallConsents": [...]
}
```

修改後（consumer 透過 `onBeforeSendMessage` 注入 payload）：
```json
{
  "action": "RESPONSE_TOOL_CALL_CONSENT",
  "customChannelId": "…",
  "customMessageId": "…",
  "payload": { "interaction_mode": "PLAN" },
  "text": "",
  "toolCallConsents": [...]
}
```

## 給整合方注意
`onBeforeSendMessage` 內的 side effect 現在也會在 consent reply 觸發。如果原本的 callback 會清掉 per-send 狀態（例如暫存的 chip references）或對 `params.text` 做 guard（`if (!params.text) throw …`），需要依用途分支判斷 — `params.text === ''` 可以可靠辨識出 consent path。

## 不在這個 PR 範圍（追蹤 follow-up）
`useChannel.replyToolCallConsents` 目前還沒把 `onSseError` / `onAuthError` 傳給 channel 那一層（pre-existing gap）。consent 失敗時只能靠 await 的 promise rejection 知道。值得另開一個 PR 補上。

## 驗證計畫
- [x] `npm run build:core` 通過
- [x] `npm run build:react` 通過
- [x] `npm run lint:packages` 通過
- [x] 實機驗證（asgard-auto-post sandbox + canary `0.2.42-canary.1`）：consent reply request body 確實帶 `payload.interaction_mode`，bot 接著用正確的 mode resume tool call