### PR TITLE
feat(react): restyle tool call consent modal to spec

### DIFF
--- a/packages/react/src/components/tool-call-consent/tool-call-consent-modal.module.scss
+++ b/packages/react/src/components/tool-call-consent/tool-call-consent-modal.module.scss
@@ -34,7 +34,7 @@
   font-size: 15px;
   font-weight: 600;
   line-height: 1.4;
-  color: var(--asgard-consent-modal-title, var(--asg-color-text-primary, #ffffff));
+  color: var(--asgard-consent-modal-headline, var(--asg-color-text-primary, #ffffff));
   word-break: break-word;
 }
 
@@ -192,7 +192,7 @@
 
 .action_primary {
   background-color: var(--asgard-consent-modal-accent, var(--asg-color-primary, #4f46e5));
-  color: #ffffff;
+  color: var(--asgard-consent-modal-primary-fg, #000000);
 
   &:hover:not(:disabled) {
     background-color: var(--asgard-consent-modal-accent-hover, var(--asg-color-primary-dark, #4338ca));
@@ -201,8 +201,8 @@
 
 .action_secondary {
   background-color: transparent;
-  color: var(--asgard-consent-modal-title, var(--asg-color-text-primary, #ffffff));
-  border-color: var(--asgard-consent-modal-border, var(--asg-color-border, #434343));
+  color: var(--asgard-consent-modal-accent, var(--asg-color-text-primary, #ffffff));
+  border-color: transparent;
 
   &:hover:not(:disabled) {
     background-color: rgba(255, 255, 255, 0.06);
@@ -212,7 +212,7 @@
 .action_danger {
   background-color: transparent;
   color: var(--asgard-consent-modal-danger, var(--asg-color-error, #dc2626));
-  border-color: var(--asgard-consent-modal-danger, var(--asg-color-error, #dc2626));
+  border-color: transparent;
 
   &:hover:not(:disabled) {
     background-color: color-mix(

--- a/packages/react/src/components/tool-call-consent/tool-call-consent-modal.tsx
+++ b/packages/react/src/components/tool-call-consent/tool-call-consent-modal.tsx
@@ -38,7 +38,6 @@ export function ToolCallConsentModal(props: ToolCallConsentModalProps): ReactNod
   const [denyReason, setDenyReason] = useState('');
 
   const { chatbot } = useAsgardThemeContext();
-  const mainColor = chatbot?.primaryComponent?.mainColor ?? chatbot?.mainColor;
   const secondaryColor = chatbot?.primaryComponent?.secondaryColor ?? chatbot?.secondaryColor;
   const inactiveColor = chatbot?.inactiveColor;
   const backgroundColor = chatbot?.backgroundColor;
@@ -47,25 +46,18 @@ export function ToolCallConsentModal(props: ToolCallConsentModalProps): ReactNod
   const themeVars = useMemo<CSSProperties>(
     () =>
       ({
-        ...(mainColor && {
-          '--asgard-consent-modal-accent': mainColor,
-          // Darken accent ~15% on hover so the primary button keeps visual feedback
-          '--asgard-consent-modal-accent-hover': `color-mix(in srgb, ${mainColor} 85%, black)`,
+        ...(secondaryColor && {
+          '--asgard-consent-modal-accent': secondaryColor,
+          '--asgard-consent-modal-accent-hover': `color-mix(in srgb, ${secondaryColor} 85%, black)`,
         }),
         ...(backgroundColor && {
           '--asgard-consent-modal-bg': backgroundColor,
           '--asgard-consent-modal-input-bg': backgroundColor,
         }),
         ...(borderColor && { '--asgard-consent-modal-border': borderColor }),
-        ...(secondaryColor && { '--asgard-consent-modal-title': secondaryColor }),
         ...(inactiveColor && { '--asgard-consent-modal-muted': inactiveColor }),
       } as CSSProperties),
-    [mainColor, backgroundColor, borderColor, secondaryColor, inactiveColor],
-  );
-
-  const primaryButtonStyle = useMemo<CSSProperties>(
-    () => (secondaryColor ? { color: secondaryColor } : {}),
-    [secondaryColor],
+    [secondaryColor, backgroundColor, borderColor, inactiveColor],
   );
 
   // Reset local state when the active pending call changes
@@ -166,12 +158,7 @@ export function ToolCallConsentModal(props: ToolCallConsentModalProps): ReactNod
         )}
 
         <div className={styles.actions}>
-          <button
-            type="button"
-            className={clsx(styles.action_btn, styles.action_primary)}
-            style={primaryButtonStyle}
-            onClick={handleAllowAlways}
-          >
+          <button type="button" className={clsx(styles.action_btn, styles.action_primary)} onClick={handleAllowAlways}>
             本次對話皆允許
           </button>
           <button type="button" className={clsx(styles.action_btn, styles.action_secondary)} onClick={handleAllowOnce}>


### PR DESCRIPTION
## Summary

依 Selena 規格(ClickUp 86exm7knd 留言 90180220946682)調整 `ToolCallConsentModal` 視覺。

| 元素 | Before | After |
|---|---|---|
| 標題 | 吃 `secondaryColor`(extension 端會變黃) | 固定白字 |
| Tool 名 | 吃 `mainColor`(extension 端深藍 on 深底,幾乎看不見) | 吃 accent(現為 `secondaryColor`) |
| 「本次對話皆允許」primary | `mainColor` 底 + `secondaryColor` 字(深藍底黃字) | accent 底 + 黑字(黃底黑字) |
| 「僅此次允許」secondary | 白字 + 邊框 | accent 字、透明底、無框 |
| 「拒絕」danger | 紅字 + 紅框 | 紅字、透明底、無框 |

### Breaking change

Consent modal 不再吃 `mainColor`,改吃 `secondaryColor` 作為 accent。原本靠 `mainColor` 染色 consent modal 的 SDK 使用者視覺會跑掉,需要改用 `secondaryColor` 或透過下列 CSS 變數 override:

- `--asgard-consent-modal-headline` — 標題文字顏色(預設白)
- `--asgard-consent-modal-accent` / `--asgard-consent-modal-accent-hover` — accent 色(預設來自 `secondaryColor`)
- `--asgard-consent-modal-primary-fg` — primary 按鈕文字顏色(預設黑)
- `--asgard-consent-modal-danger` — danger 文字顏色

## Screenshots

<img width="520" height="321" alt="01-default" src="https://github.com/user-attachments/assets/8fcfb826-a2e7-406d-b1ff-b153006c9d39" />
<img width="520" height="321" alt="02-primary-hover" src="https://github.com/user-attachments/assets/2333aac4-b1c0-4ed0-b3e7-87c2e85f82c1" />
<img width="520" height="321" alt="03-secondary-hover" src="https://github.com/user-attachments/assets/28c8148a-70de-4026-82a2-5a8b3b160040" />
<img width="520" height="321" alt="04-danger-hover" src="https://github.com/user-attachments/assets/7dd14fe3-2257-4f7d-9935-bc13f392be24" />
<img width="520" height="427" alt="05-deny-mode" src="https://github.com/user-attachments/assets/310a22b0-9975-4aae-99ca-736a8a22fff9" />

## Test plan

- [x] `npm run build:core && npm run build:react` 成功
- [x] 用 Playwright MCP 對 react-demo 驗證(extension theme: `mainColor=#1F2A37`, `secondaryColor=#f8d43c`):
  - `.title` color = `rgb(255,255,255)`
  - `.title_tool` color = `rgb(248,212,60)`
  - `.action_primary` bg = `rgb(248,212,60)` / color = `rgb(0,0,0)`
  - `.action_secondary` bg transparent / color = `rgb(248,212,60)` / border transparent
  - `.action_danger` bg transparent / color = red / border transparent
- [ ] extension repo bump `@asgard-js/react` dep 後實測(後續 PR)