### PR TITLE
fix(react): only render Attachment download icon for download_file EMIT

### DIFF
--- a/apps/react-demo/src/app/mocks/messages.ts
+++ b/apps/react-demo/src/app/mocks/messages.ts
@@ -902,7 +902,7 @@ export function createAttachmentTemplateExample(): ConversationMessage {
           },
           downloadAction: {
             type: 'emit',
-            eventName: 'my_event',
+            eventName: 'download_file',
             payload: {},
           },
         },

--- a/packages/react/src/components/templates/attachment-template/chip.tsx
+++ b/packages/react/src/components/templates/attachment-template/chip.tsx
@@ -80,6 +80,10 @@ export function AttachmentChip(props: AttachmentChipProps): ReactNode {
     [dispatchAction, downloadAction],
   );
 
+  const showDownloadIcon =
+    (downloadAction?.type === 'emit' || downloadAction?.type === 'EMIT') &&
+    downloadAction.eventName === 'download_file';
+
   return (
     <div
       role="button"
@@ -100,7 +104,7 @@ export function AttachmentChip(props: AttachmentChipProps): ReactNode {
           {text}
         </span>
       </span>
-      {downloadAction && (
+      {showDownloadIcon && (
         <button
           type="button"
           className={styles.download_button}


### PR DESCRIPTION
## 動機

`AttachmentChip` 目前只要 `downloadAction` 存在就無腦渲染右側 ⬇ 下載 icon。Heimdall 上的 BE 在「開啟檔案 CTA」(ClickUp [86exndxr5](https://app.clickup.com/t/86exndxr5)) 同時把 `defaultAction` 與 `downloadAction` 都設成 `vscode_open_file` EMIT,造成「點此開啟檔案」chip 也跳出下載 icon — 視覺誤導使用者以為可以下載。

對應的下載 CTA(ClickUp [86exnn0tx](https://app.clickup.com/t/86exnn0tx))eventName 是 `download_file`,該情境 icon 仍應顯示。

## 改動

`packages/react/src/components/templates/attachment-template/chip.tsx`
- 抽 `showDownloadIcon` const,改為只有當 `downloadAction.type === EMIT && downloadAction.eventName === 'download_file'` 才渲染下載 icon
- `handleDownloadClick` / `dispatchAction` 不動 — icon 真的被渲染時點擊行為跟以前一樣

`apps/react-demo/src/app/mocks/messages.ts`
- `createAttachmentTemplateExample()` 裡 `article-2.pdf` 的 `downloadAction.eventName` 由 `'my_event'` 改成 `'download_file'`,維持「該 chip 顯示 icon」的設計稿樣

## Trade-off(已和需求方確認)

SDK 開始知道 app-specific 字串 `download_file`(原本 `@asgard-js/*` 完全無 hardcoded eventName)。可接受的理由:`@asgard-js/*` 只服務 Asgard 生態,`download_file` 視為 de facto standard。未來若 BE 加 `download_archive` 之類新事件名要顯示 icon,需回 SDK 加白名單。

## 驗證

- [x] `npm run lint:packages` pass
- [x] `npm run build:core && npm run build:react` 成功
- [ ] `npm run serve:react-demo` → `/templates` 選 ATTACHMENT:
  - `article-1.md` / `article-3.md`:無 icon
  - `article-2.pdf`:**有** icon(eventName 已改成 `download_file`)
- [ ] 由 extension 端在 Heimdall sandbox VS Code 內 end-to-end 驗證(屬另一張 PR 的工作項)

## 不做的事

- 不 bump 版本(沿用 #252 / #253 慣例,留給之後發版另跑)
- 不改 schema、不動 `AttachmentMessageTemplate` 型別