### PR TITLE
chore(react-demo): add history-scroll-bug repro route

### DIFF
--- a/apps/react-demo/src/app/app.tsx
+++ b/apps/react-demo/src/app/app.tsx
@@ -23,6 +23,7 @@ import { OnChannelReady } from './routes/on-channel-ready';
 import { FooterEndActions } from './routes/footer-end-actions';
 import { RenderFooter } from './routes/render-footer';
 import { TextNewlines } from './routes/text-newlines';
+import { HistoryScrollBug } from './routes/history-scroll-bug';
 
 export function App(): React.ReactElement {
   return (
@@ -51,6 +52,7 @@ export function App(): React.ReactElement {
         <Route path="/footer-end-actions" element={<FooterEndActions />} />
         <Route path="/render-footer" element={<RenderFooter />} />
         <Route path="/text-newlines" element={<TextNewlines />} />
+        <Route path="/history-scroll-bug" element={<HistoryScrollBug />} />
       </Routes>
     </Layout>
   );

--- a/apps/react-demo/src/app/routes/history-scroll-bug/history-scroll-bug.module.scss
+++ b/apps/react-demo/src/app/routes/history-scroll-bug/history-scroll-bug.module.scss
@@ -1,0 +1,128 @@
+.controls {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  width: 380px;
+  flex-shrink: 0;
+
+  h3 {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1a1a2e;
+    margin: 0 0 12px 0;
+  }
+
+  code {
+    background: #f6f8fa;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    color: #d63384;
+  }
+}
+
+.desc {
+  font-size: 13px;
+  color: #444;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.steps {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 13px;
+  color: #444;
+  line-height: 1.6;
+
+  li {
+    margin: 4px 0;
+  }
+}
+
+.compare {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+
+  th,
+  td {
+    border: 1px solid #e0e0e0;
+    padding: 6px 8px;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  th {
+    background: #f6f8fa;
+    font-weight: 600;
+  }
+}
+
+.reloadButton {
+  margin-top: 16px;
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #4a9eff;
+  background: #4a9eff;
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: #3a8eef;
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+}
+
+.toggles {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 13px;
+  color: #444;
+
+  label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+
+    input {
+      cursor: pointer;
+    }
+  }
+}
+
+.loading {
+  width: 100%;
+  max-width: 480px;
+  height: 600px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #888;
+  background: #fafbfc;
+  border: 1px dashed #d0d7de;
+  border-radius: 12px;
+}
+
+.chatbotContainer {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+
+  > div {
+    width: 100%;
+    max-width: 480px;
+    height: 600px;
+  }
+}

--- a/apps/react-demo/src/app/routes/history-scroll-bug/history-scroll-bug.tsx
+++ b/apps/react-demo/src/app/routes/history-scroll-bug/history-scroll-bug.tsx
@@ -1,0 +1,229 @@
+import { ReactNode, useEffect, useState } from 'react';
+import { Chatbot } from '@asgard-js/react';
+import '@asgard-js/react/style';
+import { ConversationMessage, EventType, Message, MessageTemplateType } from '@asgard-js/core';
+import { nanoid } from 'nanoid';
+import { DemoWrapper } from '../../components/demo-wrapper';
+import { createImageTemplateExample, createUserMessageExample } from '../../mocks/messages';
+import styles from './history-scroll-bug.module.scss';
+
+// 直接做一個 bot text message,不引用 mocks 裡固定文案的 helper,
+// 這樣可以控制每則訊息的文字 + idx,讓視覺上一眼看出順序。
+function botText(text: string, idx: number): ConversationMessage {
+  const message: Message = {
+    messageId: nanoid(),
+    replyToCustomMessageId: '',
+    text,
+    payload: undefined,
+    isDebug: false,
+    idx,
+    template: {
+      type: MessageTemplateType.TEXT,
+      text,
+    },
+  };
+
+  const mockSseResponse = {
+    eventType: EventType.MESSAGE_COMPLETE,
+    fact: {
+      messageComplete: { message },
+    },
+  };
+
+  return {
+    type: 'bot',
+    messageId: message.messageId,
+    isTyping: false,
+    typingText: '',
+    eventType: EventType.MESSAGE_COMPLETE,
+    time: new Date(),
+    message,
+    raw: JSON.stringify(mockSseResponse),
+  };
+}
+
+type Variant = 'plain' | 'with-images';
+
+// 一段刻意有「對話 turn」結構的歷史訊息,結尾必為 bot
+// (bug 觸發條件:initial mount 時 last message 不是 user)。
+function buildHistory(variant: Variant): ConversationMessage[] {
+  const turns: Array<[string, string]> = [
+    ['🔝 第一則訊息 (TOP) — 重新開啟時,應該被滾出 viewport 看不到', '收到!以下是過往對話紀錄。'],
+    ['週末有什麼推薦電影?', '本週末熱門:《死侍與金鋼狼》《腦筋急轉彎 2》《異形:羅穆路斯》。'],
+    ['哺乳室在哪裡?', '影城 3F 服務台旁設有獨立哺乳室,並提供尿布台與飲水機。'],
+    ['停車場入場幾分鐘內免費?', '一般 15 分鐘內免費入場;會員可延長至 30 分鐘。'],
+    ['可以跨影城取票嗎?', '可以,網路訂票後可至全台任一秀泰影城取票。'],
+    ['有 IMAX 嗎?', '台中文心秀泰、板橋秀泰、花蓮秀泰皆設有 IMAX 廳。'],
+    ['票價怎麼計算?', '全票 NT$330,學生票 NT$280,3D / IMAX 加收 NT$50–100。'],
+    ['可以線上選位嗎?', '可以,訂票流程中會顯示廳內座位圖,直接點選即可。'],
+    ['食物可以帶進去嗎?', '影城內備有餐飲販售,外食以不影響觀影體驗為原則,謝謝您的配合。'],
+    ['今天有什麼活動?', '本日 14:00–18:00 板橋秀泰有「電影週邊快閃市集」,歡迎參加!'],
+    ['有會員制嗎?', '有,加入秀泰會員可享票價優惠、生日禮、累積點數等多項福利。'],
+    ['充電樁是哪種?', '台中文心秀泰已升級為 CCS2 新款快充樁,支援多數電動車品牌。'],
+    [
+      '🎯 最後一則 user 訊息 (倒數第二則)',
+      '🎯 最後一則 bot 訊息 (BOTTOM) — 你應該在打開瞬間就看到我,但 bug 會讓我被擋在底下!',
+    ],
+  ];
+
+  const list: ConversationMessage[] = [];
+  let idx = 0;
+  turns.forEach(([u, b], turnIdx) => {
+    list.push(createUserMessageExample(u));
+    list.push(botText(b, idx++));
+
+    // 在 variant=with-images 模式下,中間幾輪插入圖片訊息。
+    // 圖片是 async load,會在 initial mount 後造成多次 layout shift,
+    // 是觸發 bug 的關鍵 (smooth scroll 期間 content 還在長高 → race condition)。
+    if (variant === 'with-images' && [2, 5, 8].includes(turnIdx)) {
+      list.push(createImageTemplateExample(400, 240 + turnIdx * 20));
+    }
+  });
+
+  return list;
+}
+
+export function HistoryScrollBug(): ReactNode {
+  // 用 key 強制 re-mount Chatbot,模擬「重新打開 chat」
+  const [mountId, setMountId] = useState(0);
+  const [variant, setVariant] = useState<Variant>('with-images');
+
+  // 「延後注入 initMessages」模式 — 模擬從 API 載入的延遲
+  // 當 initMessages 從 [] → 大量訊息 時,content 一次暴漲,
+  // ResizeObserver/smooth scroll 之間的 race 最容易爆出來。
+  const [delayed, setDelayed] = useState(true);
+  const [messages, setMessages] = useState<ConversationMessage[]>(() => (delayed ? [] : buildHistory(variant)));
+
+  useEffect(() => {
+    setMessages([]);
+    if (!delayed) {
+      // 立即同步注入 — 不太會 repro bug 因為 layout 一次完成
+      setMessages(buildHistory(variant));
+
+      return;
+    }
+
+    // 模擬 API 載入延遲 (300ms 後注入)
+    const t = setTimeout(() => setMessages(buildHistory(variant)), 300);
+
+    return (): void => clearTimeout(t);
+  }, [mountId, variant, delayed]);
+
+  const reload = (): void => setMountId(n => n + 1);
+
+  return (
+    <DemoWrapper
+      title="History Scroll-to-Bottom Bug Repro"
+      description="重現「歷史訊息打開時，需要滾動到底下」bug (ClickUp 86exneerk)。"
+    >
+      <div className={styles.controls}>
+        <h3>🐛 Bug 描述</h3>
+        <p className={styles.desc}>
+          當 <code>initMessages</code> 注入大量歷史訊息、且最後一則為 bot message 時,Chatbot 初次掛載
+          <strong>不會自動滾到底部</strong>,最新一則訊息(BOTTOM) 會被擋在 viewport 下方。
+        </p>
+
+        <h3 style={{ marginTop: 20 }}>🔬 重現步驟</h3>
+        <ol className={styles.steps}>
+          <li>右側 chatbot 應該看到一則寫著「🔝 第一則訊息 (TOP)」的 bot bubble。</li>
+          <li>觀察 chatbot 開啟時,scroll thumb 位置是否在「中段」而非「最底」。</li>
+          <li>標 🎯 的「最後一則 bot 訊息 (BOTTOM)」應在底部,但 bug 時它被擋住。</li>
+          <li>
+            點下方 <strong>Reload Chatbot</strong> 用 key 換掉觸發 re-mount,反覆觀察。
+          </li>
+        </ol>
+
+        <h3 style={{ marginTop: 20 }}>🎛️ 觸發條件設定</h3>
+        <div className={styles.toggles}>
+          <label>
+            <input
+              type="checkbox"
+              checked={variant === 'with-images'}
+              onChange={e => setVariant(e.target.checked ? 'with-images' : 'plain')}
+            />
+            <span>插入圖片訊息 (async load,觸發 layout shift)</span>
+          </label>
+          <label>
+            <input type="checkbox" checked={delayed} onChange={e => setDelayed(e.target.checked)} />
+            <span>延後 300ms 注入 initMessages (模擬 API 載入)</span>
+          </label>
+        </div>
+
+        <h3 style={{ marginTop: 20 }}>🎯 期待 vs 實際</h3>
+        <table className={styles.compare}>
+          <thead>
+            <tr>
+              <th></th>
+              <th>期待</th>
+              <th>實際 (bug)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>初始位置</td>
+              <td>滾到底,看到 🎯 BOTTOM</td>
+              <td>停在中段,只看到中間幾則</td>
+            </tr>
+            <tr>
+              <td>scrollTop</td>
+              <td>= scrollHeight − clientHeight</td>
+              <td>&lt; scrollHeight − clientHeight</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <button className={styles.reloadButton} onClick={reload}>
+          🔄 Reload Chatbot (re-mount #{mountId})
+        </button>
+
+        <h3 style={{ marginTop: 20 }}>📍 Bug 假設</h3>
+        <p className={styles.desc}>
+          <strong>Race condition</strong> 在 <code>programmaticScrollToBottom('smooth')</code> 之間與{' '}
+          <code>handleScroll</code> 之間:
+        </p>
+        <ol className={styles.steps}>
+          <li>
+            Initial mount, <code>isFollowingLatest=true</code>。
+          </li>
+          <li>
+            ResizeObserver fire → <code>programmaticScrollToBottom('smooth')</code> 啟動 smooth scroll。
+          </li>
+          <li>
+            Smooth scroll 動畫期間 <strong>瀏覽器一直 fire 'scroll' events</strong>。
+          </li>
+          <li>
+            <code>handleScroll</code> 看到中間 frame 的 <code>distanceFromBottom &gt; 50</code> → 把{' '}
+            <code>isFollowingLatest</code> 設成 <code>false</code>。
+          </li>
+          <li>
+            之後 image / markdown async layout 完成,content 又長高 → ResizeObserver 再 fire,但{' '}
+            <code>isFollowingLatest=false</code> 就不滾了。
+          </li>
+          <li>Smooth scroll 動畫停在原本算的 target,但 content 已長高 → 永遠到不了真正的底。</li>
+        </ol>
+        <p className={styles.desc} style={{ marginTop: 8 }}>
+          相關檔案:
+          <br />
+          <code>packages/react/src/components/chatbot/chatbot-body/chatbot-body.tsx</code> 85–132 行<br />
+          <code>packages/react/src/context/asgard-service-context.tsx</code> 167–189 行
+        </p>
+      </div>
+
+      <div className={styles.chatbotContainer}>
+        {messages.length === 0 ? (
+          <div className={styles.loading}>
+            <span>Loading messages…</span>
+          </div>
+        ) : (
+          <Chatbot
+            key={`${mountId}-${variant}-${delayed ? 'd' : 'i'}`}
+            title={`歷史對話 (${messages.length} msgs)`}
+            config={{ botProviderEndpoint: 'skip' }}
+            customChannelId={`history-scroll-bug-${mountId}`}
+            initMessages={messages}
+          />
+        )}
+      </div>
+    </DemoWrapper>
+  );
+}

--- a/apps/react-demo/src/app/routes/history-scroll-bug/index.ts
+++ b/apps/react-demo/src/app/routes/history-scroll-bug/index.ts
@@ -1,0 +1,1 @@
+export * from './history-scroll-bug';

--- a/apps/react-demo/src/app/routes/home/home.tsx
+++ b/apps/react-demo/src/app/routes/home/home.tsx
@@ -47,6 +47,11 @@ const demoCards = [
     description: 'Test chatbot with a private bot provider requiring authentication.',
     to: '/private',
   },
+  {
+    title: '🐛 History Scroll Bug',
+    description: 'Repro: chat does not scroll to bottom when opened with pre-existing history (ClickUp 86exneerk).',
+    to: '/history-scroll-bug',
+  },
 ];
 
 export function Home(): ReactNode {


### PR DESCRIPTION
## Summary

新增 `/history-scroll-bug` route,用來重現「歷史訊息打開時，需要滾動到底下」這個 bug ([ClickUp 86exneerk](https://app.clickup.com/t/86exneerk))。

## 現象

當 Chatbot 用 `initMessages` 注入大量歷史訊息、且其中含有 async-loading 的內容 (例如圖片) 時,初次掛載**不會滾到底部**,最新一則 bot 訊息會被擋在 viewport 下方。

| Variant | distanceFromBottom | 結果 |
|---|---|---|
| 純文字 (control) | **0** | ✅ 正常滾到底 |
| 含圖片 (default) | **> 0** | 🐛 Bug 重現 |

對照組 (純文字) 不會 repro,直接證明問題與 async layout shift 相關。

## Race condition (Bug 假設)

1. Initial mount,`isFollowingLatest = true`。
2. ResizeObserver fire → `programmaticScrollToBottom('smooth')` 啟動 smooth scroll 動畫。
3. Smooth 動畫期間瀏覽器一直 fire native `scroll` events。
4. `chatbot-body.tsx` 的 `handleScroll` 在中間 frame 看到 `distanceFromBottom > 50`,把 `isFollowingLatest` 設成 `false`。
5. 之後圖片 async load 完成,content 又長高 → ResizeObserver 再 fire,但因為 `isFollowingLatest = false` 不再追。
6. Smooth scroll 停在原本算的 target,content 已長高 → 永遠到不了真正的底。

## 相關檔案

- `packages/react/src/components/chatbot/chatbot-body/chatbot-body.tsx` 85–132 行 (handleScroll + ResizeObserver effect)
- `packages/react/src/context/asgard-service-context.tsx` 167–189 行 (`programmaticScrollToBottom` 使用 `behavior: 'smooth'`)

## 這個 PR 只新增 repro

不含 fix。Bug 修法 (例如 `behavior: 'auto'`、smooth scroll 期間暫時停掉 handleScroll、或 initial mount 用 `useLayoutEffect` + `requestAnimationFrame`) 留待下一個 PR。

## Test plan

- [ ] `npm run serve:react-demo` 啟動,打開 http://localhost:4200/history-scroll-bug
- [ ] 預設狀態 (含圖片 + 延後 300ms 注入):chatbot 開啟後 scroll thumb 停在中段,看不到「🎯 BOTTOM」那則
- [ ] 取消勾「插入圖片訊息」:chatbot 開啟後正常滾到底,看得到「🎯 BOTTOM」
- [ ] 點 `🔄 Reload Chatbot` 反覆觸發 re-mount,bug 都會重現