### PR TITLE
fix(react): scroll to bottom synchronously on initial mount

### DIFF
--- a/apps/react-demo/src/app/app.tsx
+++ b/apps/react-demo/src/app/app.tsx
@@ -23,6 +23,7 @@ import { OnChannelReady } from './routes/on-channel-ready';
 import { FooterEndActions } from './routes/footer-end-actions';
 import { RenderFooter } from './routes/render-footer';
 import { TextNewlines } from './routes/text-newlines';
+import { HistoryScrollBug } from './routes/history-scroll-bug';
 
 export function App(): React.ReactElement {
   return (
@@ -51,6 +52,7 @@ export function App(): React.ReactElement {
         <Route path="/footer-end-actions" element={<FooterEndActions />} />
         <Route path="/render-footer" element={<RenderFooter />} />
         <Route path="/text-newlines" element={<TextNewlines />} />
+        <Route path="/history-scroll-bug" element={<HistoryScrollBug />} />
       </Routes>
     </Layout>
   );

--- a/apps/react-demo/src/app/routes/history-scroll-bug/history-scroll-bug.module.scss
+++ b/apps/react-demo/src/app/routes/history-scroll-bug/history-scroll-bug.module.scss
@@ -1,0 +1,151 @@
+.controls {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  width: 380px;
+  flex-shrink: 0;
+
+  h3 {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1a1a2e;
+    margin: 0 0 12px 0;
+  }
+
+  code {
+    background: #f6f8fa;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    color: #d63384;
+  }
+}
+
+.desc {
+  font-size: 13px;
+  color: #444;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.steps {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 13px;
+  color: #444;
+  line-height: 1.6;
+
+  li {
+    margin: 4px 0;
+  }
+}
+
+.compare {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+
+  th,
+  td {
+    border: 1px solid #e0e0e0;
+    padding: 6px 8px;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  th {
+    background: #f6f8fa;
+    font-weight: 600;
+  }
+}
+
+.reloadButton {
+  margin-top: 16px;
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #4a9eff;
+  background: #4a9eff;
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: #3a8eef;
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+}
+
+.toggles {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 13px;
+  color: #444;
+
+  label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+
+    input {
+      cursor: pointer;
+    }
+  }
+}
+
+.variantGroup {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 8px 12px 10px;
+  margin: 0 0 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  legend {
+    font-size: 12px;
+    font-weight: 600;
+    color: #666;
+    padding: 0 6px;
+  }
+
+  label {
+    font-size: 13px;
+    align-items: flex-start;
+    line-height: 1.4;
+  }
+}
+
+.loading {
+  width: 100%;
+  max-width: 480px;
+  height: 600px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #888;
+  background: #fafbfc;
+  border: 1px dashed #d0d7de;
+  border-radius: 12px;
+}
+
+.chatbotContainer {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+
+  > div {
+    width: 100%;
+    max-width: 480px;
+    height: 600px;
+  }
+}

--- a/apps/react-demo/src/app/routes/history-scroll-bug/history-scroll-bug.tsx
+++ b/apps/react-demo/src/app/routes/history-scroll-bug/history-scroll-bug.tsx
@@ -1,0 +1,309 @@
+import { ReactNode, useEffect, useState } from 'react';
+import { Chatbot } from '@asgard-js/react';
+import '@asgard-js/react/style';
+import { ConversationMessage, EventType, Message, MessageTemplateType } from '@asgard-js/core';
+import { nanoid } from 'nanoid';
+import { DemoWrapper } from '../../components/demo-wrapper';
+import {
+  createAttachmentTemplateExample,
+  createButtonTemplateExample,
+  createCarouselTemplateExample,
+  createChartTemplateExample,
+  createHintTemplateExample,
+  createImageTemplateExample,
+  createMathTemplateExample,
+  createTableTemplateExample,
+  createUserMessageExample,
+} from '../../mocks/messages';
+import styles from './history-scroll-bug.module.scss';
+
+// 直接做一個 bot text message,不引用 mocks 裡固定文案的 helper,
+// 這樣可以控制每則訊息的文字 + idx,讓視覺上一眼看出順序。
+function botText(text: string, idx: number): ConversationMessage {
+  const message: Message = {
+    messageId: nanoid(),
+    replyToCustomMessageId: '',
+    text,
+    payload: undefined,
+    isDebug: false,
+    idx,
+    template: {
+      type: MessageTemplateType.TEXT,
+      text,
+    },
+  };
+
+  const mockSseResponse = {
+    eventType: EventType.MESSAGE_COMPLETE,
+    fact: {
+      messageComplete: { message },
+    },
+  };
+
+  return {
+    type: 'bot',
+    messageId: message.messageId,
+    isTyping: false,
+    typingText: '',
+    eventType: EventType.MESSAGE_COMPLETE,
+    time: new Date(),
+    message,
+    raw: JSON.stringify(mockSseResponse),
+  };
+}
+
+type Variant = 'plain' | 'with-images' | 'with-rich-templates';
+
+// 各 turnIdx 對應插入哪個 rich template — 用陣列控制順序,讓不同類型的 template 都被涵蓋
+function richTemplateFor(turnIdx: number): ConversationMessage | null {
+  switch (turnIdx) {
+    case 1:
+      return createHintTemplateExample();
+    case 2:
+      return createImageTemplateExample(400, 260);
+    case 3:
+      return createButtonTemplateExample();
+    case 5:
+      return createCarouselTemplateExample();
+    case 6:
+      return createMathTemplateExample();
+    case 8:
+      return createChartTemplateExample();
+    case 9:
+      return createTableTemplateExample();
+    case 11:
+      return createAttachmentTemplateExample();
+    default:
+      return null;
+  }
+}
+
+// 一段刻意有「對話 turn」結構的歷史訊息,結尾必為 bot
+// (bug 觸發條件:initial mount 時 last message 不是 user)。
+function buildHistory(variant: Variant): ConversationMessage[] {
+  const turns: Array<[string, string]> = [
+    ['🔝 第一則訊息 (TOP) — 重新開啟時,應該被滾出 viewport 看不到', '收到!以下是過往對話紀錄。'],
+    ['週末有什麼推薦電影?', '本週末熱門:《死侍與金鋼狼》《腦筋急轉彎 2》《異形:羅穆路斯》。'],
+    ['哺乳室在哪裡?', '影城 3F 服務台旁設有獨立哺乳室,並提供尿布台與飲水機。'],
+    ['停車場入場幾分鐘內免費?', '一般 15 分鐘內免費入場;會員可延長至 30 分鐘。'],
+    ['可以跨影城取票嗎?', '可以,網路訂票後可至全台任一秀泰影城取票。'],
+    ['有 IMAX 嗎?', '台中文心秀泰、板橋秀泰、花蓮秀泰皆設有 IMAX 廳。'],
+    ['票價怎麼計算?', '全票 NT$330,學生票 NT$280,3D / IMAX 加收 NT$50–100。'],
+    ['可以線上選位嗎?', '可以,訂票流程中會顯示廳內座位圖,直接點選即可。'],
+    ['食物可以帶進去嗎?', '影城內備有餐飲販售,外食以不影響觀影體驗為原則,謝謝您的配合。'],
+    ['今天有什麼活動?', '本日 14:00–18:00 板橋秀泰有「電影週邊快閃市集」,歡迎參加!'],
+    ['有會員制嗎?', '有,加入秀泰會員可享票價優惠、生日禮、累積點數等多項福利。'],
+    ['充電樁是哪種?', '台中文心秀泰已升級為 CCS2 新款快充樁,支援多數電動車品牌。'],
+    [
+      '🎯 最後一則 user 訊息 (倒數第二則)',
+      '🎯 最後一則 bot 訊息 (BOTTOM) — 你應該在打開瞬間就看到我,但 bug 會讓我被擋在底下!',
+    ],
+  ];
+
+  const list: ConversationMessage[] = [];
+  let idx = 0;
+  turns.forEach(([u, b], turnIdx) => {
+    list.push(createUserMessageExample(u));
+    list.push(botText(b, idx++));
+
+    if (variant === 'with-images' && [2, 5, 8].includes(turnIdx)) {
+      // 純圖片版 — 只插入 async-load 圖片,專注觀察 race condition
+      list.push(createImageTemplateExample(400, 240 + turnIdx * 20));
+    } else if (variant === 'with-rich-templates') {
+      // 完整 rich template 版 — 涵蓋 SDK 支援的多種 template 類型
+      const rich = richTemplateFor(turnIdx);
+
+      if (rich) list.push(rich);
+    }
+  });
+
+  return list;
+}
+
+type Mode = 'preview' | 'mock';
+
+export function HistoryScrollBug(): ReactNode {
+  // 用 key 強制 re-mount Chatbot,模擬「重新打開 chat」
+  const [mountId, setMountId] = useState(0);
+  const [variant, setVariant] = useState<Variant>('with-images');
+  // preview: botProviderEndpoint='skip' (input disabled, 純展示歷史)
+  // mock:    botProviderEndpoint='/mock-asgard' (走真網路,由 vite middleware 攔截回 SSE)
+  // 預設 mock,user 可以直接送訊息測 streaming;要看純歷史 bug 才切 preview。
+  const [mode, setMode] = useState<Mode>('mock');
+
+  // 「延後注入 initMessages」模式 — 模擬從 API 載入的延遲
+  // 當 initMessages 從 [] → 大量訊息 時,content 一次暴漲,
+  // ResizeObserver/smooth scroll 之間的 race 最容易爆出來。
+  const [delayed, setDelayed] = useState(true);
+  const [messages, setMessages] = useState<ConversationMessage[]>(() => (delayed ? [] : buildHistory(variant)));
+
+  useEffect(() => {
+    setMessages([]);
+    if (!delayed) {
+      // 立即同步注入 — 不太會 repro bug 因為 layout 一次完成
+      setMessages(buildHistory(variant));
+
+      return;
+    }
+
+    // 模擬 API 載入延遲 (300ms 後注入)
+    const t = setTimeout(() => setMessages(buildHistory(variant)), 300);
+
+    return (): void => clearTimeout(t);
+  }, [mountId, variant, delayed]);
+
+  const reload = (): void => setMountId(n => n + 1);
+
+  return (
+    <DemoWrapper
+      title="History Scroll-to-Bottom Bug Repro"
+      description="重現「歷史訊息打開時，需要滾動到底下」bug (ClickUp 86exneerk)。"
+    >
+      <div className={styles.controls}>
+        <h3>🐛 Bug 描述</h3>
+        <p className={styles.desc}>
+          當 <code>initMessages</code> 注入大量歷史訊息、且最後一則為 bot message 時,Chatbot 初次掛載
+          <strong>不會自動滾到底部</strong>,最新一則訊息(BOTTOM) 會被擋在 viewport 下方。
+        </p>
+
+        <h3 style={{ marginTop: 20 }}>🔬 重現步驟</h3>
+        <ol className={styles.steps}>
+          <li>右側 chatbot 應該看到一則寫著「🔝 第一則訊息 (TOP)」的 bot bubble。</li>
+          <li>觀察 chatbot 開啟時,scroll thumb 位置是否在「中段」而非「最底」。</li>
+          <li>標 🎯 的「最後一則 bot 訊息 (BOTTOM)」應在底部,但 bug 時它被擋住。</li>
+          <li>
+            點下方 <strong>Reload Chatbot</strong> 用 key 換掉觸發 re-mount,反覆觀察。
+          </li>
+        </ol>
+
+        <h3 style={{ marginTop: 20 }}>🎛️ 觸發條件設定</h3>
+        <div className={styles.toggles}>
+          <fieldset className={styles.variantGroup}>
+            <legend>對話模式 (input 是否可用)</legend>
+            <label>
+              <input type="radio" name="mode" checked={mode === 'mock'} onChange={() => setMode('mock')} />
+              <span>
+                <strong>Mock SSE</strong> — input 可送 (vite middleware 回 streaming bot reply),測 send-after /
+                streaming scroll
+              </span>
+            </label>
+            <label>
+              <input type="radio" name="mode" checked={mode === 'preview'} onChange={() => setMode('preview')} />
+              <span>
+                <strong>Preview</strong> — input disabled,純展示歷史 (<code>botProviderEndpoint: 'skip'</code>)
+              </span>
+            </label>
+          </fieldset>
+          <fieldset className={styles.variantGroup}>
+            <legend>歷史訊息內容</legend>
+            <label>
+              <input type="radio" name="variant" checked={variant === 'plain'} onChange={() => setVariant('plain')} />
+              <span>純文字 (control — 不會 repro bug)</span>
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="variant"
+                checked={variant === 'with-images'}
+                onChange={() => setVariant('with-images')}
+              />
+              <span>插入圖片 (async load,專注觀察 race condition)</span>
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="variant"
+                checked={variant === 'with-rich-templates'}
+                onChange={() => setVariant('with-rich-templates')}
+              />
+              <span>完整 rich templates (hint / image / button / carousel / math / chart / table / attachment)</span>
+            </label>
+          </fieldset>
+          <label>
+            <input type="checkbox" checked={delayed} onChange={e => setDelayed(e.target.checked)} />
+            <span>延後 300ms 注入 initMessages (模擬 API 載入)</span>
+          </label>
+        </div>
+
+        <h3 style={{ marginTop: 20 }}>🎯 期待 vs 實際</h3>
+        <table className={styles.compare}>
+          <thead>
+            <tr>
+              <th></th>
+              <th>期待</th>
+              <th>實際 (bug)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>初始位置</td>
+              <td>滾到底,看到 🎯 BOTTOM</td>
+              <td>停在中段,只看到中間幾則</td>
+            </tr>
+            <tr>
+              <td>scrollTop</td>
+              <td>= scrollHeight − clientHeight</td>
+              <td>&lt; scrollHeight − clientHeight</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <button className={styles.reloadButton} onClick={reload}>
+          🔄 Reload Chatbot (re-mount #{mountId})
+        </button>
+
+        <h3 style={{ marginTop: 20 }}>📍 Bug 假設</h3>
+        <p className={styles.desc}>
+          <strong>Race condition</strong> 在 <code>programmaticScrollToBottom('smooth')</code> 之間與{' '}
+          <code>handleScroll</code> 之間:
+        </p>
+        <ol className={styles.steps}>
+          <li>
+            Initial mount, <code>isFollowingLatest=true</code>。
+          </li>
+          <li>
+            ResizeObserver fire → <code>programmaticScrollToBottom('smooth')</code> 啟動 smooth scroll。
+          </li>
+          <li>
+            Smooth scroll 動畫期間 <strong>瀏覽器一直 fire 'scroll' events</strong>。
+          </li>
+          <li>
+            <code>handleScroll</code> 看到中間 frame 的 <code>distanceFromBottom &gt; 50</code> → 把{' '}
+            <code>isFollowingLatest</code> 設成 <code>false</code>。
+          </li>
+          <li>
+            之後 image / markdown async layout 完成,content 又長高 → ResizeObserver 再 fire,但{' '}
+            <code>isFollowingLatest=false</code> 就不滾了。
+          </li>
+          <li>Smooth scroll 動畫停在原本算的 target,但 content 已長高 → 永遠到不了真正的底。</li>
+        </ol>
+        <p className={styles.desc} style={{ marginTop: 8 }}>
+          相關檔案:
+          <br />
+          <code>packages/react/src/components/chatbot/chatbot-body/chatbot-body.tsx</code> 85–132 行<br />
+          <code>packages/react/src/context/asgard-service-context.tsx</code> 167–189 行
+        </p>
+      </div>
+
+      <div className={styles.chatbotContainer}>
+        {messages.length === 0 ? (
+          <div className={styles.loading}>
+            <span>Loading messages…</span>
+          </div>
+        ) : (
+          <Chatbot
+            key={`${mountId}-${variant}-${delayed ? 'd' : 'i'}-${mode}`}
+            title={`歷史對話 (${messages.length} msgs, ${mode})`}
+            config={
+              mode === 'mock'
+                ? { botProviderEndpoint: `${window.location.origin}/mock-asgard` }
+                : { botProviderEndpoint: 'skip' }
+            }
+            customChannelId={`history-scroll-bug-${mountId}`}
+            initMessages={messages}
+          />
+        )}
+      </div>
+    </DemoWrapper>
+  );
+}

--- a/apps/react-demo/src/app/routes/history-scroll-bug/index.ts
+++ b/apps/react-demo/src/app/routes/history-scroll-bug/index.ts
@@ -1,0 +1,1 @@
+export * from './history-scroll-bug';

--- a/apps/react-demo/src/app/routes/home/home.tsx
+++ b/apps/react-demo/src/app/routes/home/home.tsx
@@ -47,6 +47,11 @@ const demoCards = [
     description: 'Test chatbot with a private bot provider requiring authentication.',
     to: '/private',
   },
+  {
+    title: '🐛 History Scroll Bug',
+    description: 'Repro: chat does not scroll to bottom when opened with pre-existing history (ClickUp 86exneerk).',
+    to: '/history-scroll-bug',
+  },
 ];
 
 export function Home(): ReactNode {

--- a/apps/react-demo/src/mock-server/sse-mock.ts
+++ b/apps/react-demo/src/mock-server/sse-mock.ts
@@ -1,0 +1,202 @@
+// 本地 mock SSE handler,給 Vite dev server 用。
+// 攔截 POST `/mock-asgard/message/sse`,回傳一段預設好的 streaming bot reply,
+// 不接真實 Asgard backend,純測 SDK 的 send-message + streaming scroll 行為。
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+
+interface ParsedPayload {
+  customChannelId?: string;
+  customMessageId?: string;
+  text?: string;
+  action?: string;
+}
+
+function readBody(req: IncomingMessage): Promise<ParsedPayload> {
+  return new Promise(resolve => {
+    const chunks: Buffer[] = [];
+
+    req.on('data', chunk => chunks.push(chunk));
+    req.on('end', () => {
+      try {
+        const body = Buffer.concat(chunks).toString('utf-8');
+
+        resolve(JSON.parse(body) as ParsedPayload);
+      } catch {
+        resolve({});
+      }
+    });
+    req.on('error', () => resolve({}));
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+const NAMESPACE = 'mock-namespace';
+const BOT_PROVIDER_NAME = 'mock-bot-provider';
+
+// 預設的長回覆 (~28 個 deltas),夠 overflow 一個高度 600px 的 chatbot,
+// 讓 scroll follow-bottom 行為在 streaming 過程中可被觀察。
+const REPLY_CHUNKS = [
+  '收到 ',
+  '你的訊息了！',
+  '我來回覆',
+  '一段較長',
+  '的內容，',
+  '主要是為了',
+  '測試 chatbot ',
+  '在 streaming ',
+  '過程中,',
+  '滾動是否能',
+  '一直貼著底部。',
+  '\n\n首先，',
+  '當 bot 訊息一邊到達、',
+  '一邊渲染時，',
+  'ResizeObserver ',
+  '會持續 fire，',
+  '觸發 programmaticScrollToBottom，',
+  '視窗應該',
+  '持續貼底。',
+  '\n\n其次，',
+  '使用者送出訊息',
+  '的瞬間，',
+  'scrollToBottom ',
+  '會 snap 到底，',
+  '並重置 ',
+  'isFollowingLatest=true。',
+  '\n\n最後一段',
+  '是收尾，完整訊息會在 ',
+  'message.complete ',
+  '時被換成 final template。',
+];
+
+function writeEvent(res: ServerResponse, event: object): void {
+  res.write(`data: ${JSON.stringify(event)}\n\n`);
+}
+
+interface CommonHeader {
+  requestId: string;
+  namespace: string;
+  botProviderName: string;
+  customChannelId: string;
+}
+
+function emptyFact(): Record<string, unknown> {
+  return {
+    runInit: null,
+    runDone: null,
+    runError: null,
+    messageStart: null,
+    messageDelta: null,
+    messageComplete: null,
+    toolCallStart: null,
+    toolCallComplete: null,
+    toolCallConsent: null,
+  };
+}
+
+export async function handleMockSse(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    res.end();
+
+    return;
+  }
+
+  const payload = await readBody(req);
+  const requestId = randomUUID();
+  const customChannelId = payload.customChannelId ?? 'mock-channel';
+  const replyToCustomMessageId = payload.customMessageId ?? '';
+  const messageId = randomUUID();
+  const fullText = REPLY_CHUNKS.join('');
+
+  const header: CommonHeader = {
+    requestId,
+    namespace: NAMESPACE,
+    botProviderName: BOT_PROVIDER_NAME,
+    customChannelId,
+  };
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive',
+  });
+
+  // 1. run.init
+  writeEvent(res, { ...header, eventType: 'asgard.run.init', fact: { ...emptyFact(), runInit: {} } });
+  await sleep(40);
+
+  // 2. message.start (空 text,bot 訊息進入 isTyping 狀態)
+  writeEvent(res, {
+    ...header,
+    eventType: 'asgard.message.start',
+    fact: {
+      ...emptyFact(),
+      messageStart: {
+        message: {
+          messageId,
+          replyToCustomMessageId,
+          text: '',
+          payload: null,
+          isDebug: false,
+          idx: null,
+          template: { type: 'TEXT', text: '' },
+        },
+      },
+    },
+  });
+
+  // 3. message.delta * N — 每 60ms 一筆,模擬真實 LLM streaming
+  let idx = 0;
+
+  for (const chunk of REPLY_CHUNKS) {
+    await sleep(60);
+    writeEvent(res, {
+      ...header,
+      eventType: 'asgard.message.delta',
+      fact: {
+        ...emptyFact(),
+        messageDelta: {
+          message: {
+            messageId,
+            replyToCustomMessageId,
+            text: chunk,
+            payload: null,
+            isDebug: false,
+            idx: idx++,
+            template: null,
+          },
+        },
+      },
+    });
+  }
+
+  await sleep(40);
+
+  // 4. message.complete (final 文字 + template)
+  writeEvent(res, {
+    ...header,
+    eventType: 'asgard.message.complete',
+    fact: {
+      ...emptyFact(),
+      messageComplete: {
+        message: {
+          messageId,
+          replyToCustomMessageId,
+          text: fullText,
+          payload: null,
+          isDebug: false,
+          idx: null,
+          template: { type: 'TEXT', text: fullText },
+        },
+      },
+    },
+  });
+
+  // 5. run.done
+  writeEvent(res, { ...header, eventType: 'asgard.run.done', fact: { ...emptyFact(), runDone: {} } });
+
+  res.end();
+}

--- a/apps/react-demo/vite.config.ts
+++ b/apps/react-demo/vite.config.ts
@@ -1,8 +1,27 @@
 /// <reference types='vitest' />
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+// Dev-only: 在 dev server 內攔截 POST `/mock-asgard/message/sse`，回傳 streaming SSE，
+// 讓 demo 不需要真實 Asgard backend 也能測 send-message + bot streaming 行為。
+function asgardSseMockPlugin(): Plugin {
+  return {
+    name: 'asgard-sse-mock',
+    configureServer(server) {
+      server.middlewares.use('/mock-asgard/message/sse', async (req, res, next) => {
+        try {
+          const { handleMockSse } = await import('./src/mock-server/sse-mock');
+
+          await handleMockSse(req, res);
+        } catch (err) {
+          next(err as Error);
+        }
+      });
+    },
+  };
+}
 
 export default defineConfig(() => ({
   root: __dirname,
@@ -15,7 +34,7 @@ export default defineConfig(() => ({
     port: 4200,
     host: 'localhost',
   },
-  plugins: [react(), svgr(), nxViteTsPaths()],
+  plugins: [react(), svgr(), nxViteTsPaths(), asgardSseMockPlugin()],
   build: {
     outDir: './dist',
     emptyOutDir: true,

--- a/packages/react/src/components/chatbot/chatbot-body/chatbot-body.tsx
+++ b/packages/react/src/components/chatbot/chatbot-body/chatbot-body.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
+import { Fragment, ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { ConversationMessage, ConversationToolCallMessage } from '@asgard-js/core';
 import { useAsgardContext } from '../../../context/asgard-service-context';
 import styles from './chatbot-body.module.scss';
@@ -81,6 +81,29 @@ export function ChatbotBody(): ReactNode {
 
   const lastMessageCountRef = useRef<number>(0);
   const contentRef = useRef<HTMLDivElement>(null);
+  const didInitialScrollRef = useRef<boolean>(false);
+
+  // 初次有 messages 時，在 browser paint 之前同步把 chat 滾到底，避免：
+  // 1. 看到「先頂部 → 然後跳/滾到底」的閃爍
+  // 2. ResizeObserver + 'smooth' scroll 的 race condition — smooth 動畫期間
+  //    fire 的 'scroll' events 會被下方 handleScroll 誤判為使用者滾走，把
+  //    isFollowingLatest 設成 false，後續 async 內容（例如圖片載入）造成的
+  //    layout 增高就不再被追，scroll 停在半路。
+  // useLayoutEffect 在 commit DOM 之後、瀏覽器 paint 之前同步執行；
+  // 此時 scroll 事件監聽器（下方 useEffect）尚未掛上，所以直接設 scrollTop
+  // 不會觸發 handleScroll，也就不會錯誤更新 isFollowingLatest。
+  useLayoutEffect(() => {
+    if (didInitialScrollRef.current) return;
+
+    if (!messages || messages.size === 0) return;
+
+    const container = scrollContainerRef.current;
+
+    if (!container) return;
+
+    container.scrollTop = container.scrollHeight;
+    didInitialScrollRef.current = true;
+  }, [messages, scrollContainerRef]);
 
   // 監聽滾動事件，根據距離底部的距離判斷是否跟隨
   useEffect(() => {


### PR DESCRIPTION
對應 [ClickUp 86exneerk](https://app.clickup.com/t/86exneerk)「歷史訊息打開時，需要滾動到底下」。

本 PR 包含 3 個 commit:

| Commit | 內容 |
|---|---|
| `chore(react-demo): add history-scroll-bug repro route` | 新增 `/history-scroll-bug` demo 路由(toggle、reload 按鈕),重現 + 驗證 bug |
| `fix(react): scroll to bottom synchronously on initial mount` | **本 PR 主修法** — 在 `chatbot-body.tsx` 加 `useLayoutEffect`,初次 `messages` 有內容時同步 `scrollTop = scrollHeight` |
| `chore(react-demo): add mock SSE middleware for streaming testing` | 在 react-demo 加 Vite middleware,攔截 `/mock-asgard/message/sse` 回傳 streaming SSE,讓 demo 不需真實 backend 也能測 send-message + bot streaming |

## Bug

當 Chatbot 用 `initMessages` 注入歷史對話時,初次掛載沒有正確滾到底。兩種失敗模式:

1. **同步 render 的內容** — 現有 smooth scroll 動畫期間,user 會看到「先頂部 → 然後滑到底」的閃爍。
2. **含 async 內容 (圖片附件等)** — smooth scroll 期間 fire 的 native `'scroll'` events 被 `handleScroll` 誤判為「使用者滾走」,把 `isFollowingLatest` 設成 `false`;之後 image load 造成 layout 增高時,ResizeObserver 雖然 fire 但被 `isFollowingLatest=false` 擋掉,scroll 永遠停在半路,最新訊息被擋在底下。

## Fix

在 `chatbot-body.tsx` 新增一個 `useLayoutEffect`,初次 `messages` 有內容時、瀏覽器 paint 之前同步把 `scrollTop = scrollHeight`。

關鍵時機:
- `useLayoutEffect` 在 React commit DOM 之後、browser paint 之前同步執行,user 第一幀就是底。
- 這個時間點 scroll event listener (在下方 regular `useEffect`) **還沒掛上**,所以直接設 `scrollTop` 不會觸發 `handleScroll`,`isFollowingLatest` 維持 `true`。
- 後續 async 內容載入造成 layout 增高時,ResizeObserver 仍能正常追到底。
- `didInitialScrollRef` ref 確保只 fire 一次,後續 send-message / streaming 不會誤觸發。

## 不動的部分

- 使用者送訊息的 smooth scroll (`chatbot-body.tsx` `scrollToBottom('smooth')`) — 保留。
- ResizeObserver 跟隨 streaming bot 訊息的 smooth scroll (`programmaticScrollToBottom('smooth')`) — 保留。
- iOS 鍵盤 focus 的 smooth scroll (`chatbot-footer.tsx`) — 保留。
- streaming 過程中如果 content 同時急速長高,`handleScroll` 仍可能在 smooth 動畫期間誤判 → race condition 還在,但**不是本 ticket 範圍**,留 follow-up。

## Mock SSE middleware

Vite dev-server middleware 在 `/apps/react-demo/src/mock-server/sse-mock.ts`,只在 dev mode 生效。
- 攔截 `POST /mock-asgard/message/sse`
- 預設回覆: `run.init` → `message.start` → 28 個 `message.delta` (每 60ms) → `message.complete` → `run.done`
- 不影響其他既有 demo route(中間 path `mock-asgard` 不會撞)
- 註:SDK 用 `new URL(endpoint)` 解析 endpoint,所以 demo 端用 `${window.location.origin}/mock-asgard`(absolute URL)而非相對路徑

## 驗證

用本 PR 加的 `/history-scroll-bug` route 驗證:

### Preview mode (history initial scroll bug)

| 情境 | 修前 distanceFromBottom | 修後 |
|---|---|---|
| 純文字歷史 (control) | 0 | 0 ✓ |
| 含圖片歷史 (default) | **736** (卡半路) | **0 ✓** |
| Reload 重複 3 次 | (race 機率出現) | 每次都 0 ✓ |

### Mock SSE mode (send-message + streaming)

| 階段 | distanceFromBottom |
|---|---|
| 送出訊息瞬間 (t=1s) | 0 ✓ |
| Streaming 中段 (t=4s, scrollHeight 持續增加 4038→4294) | 0 ✓ |
| Bot complete (t=8s) | 0 ✓ |

`useLayoutEffect` 只在第一次有 messages 時 fire,後續 send-message 走原本的 `scrollToBottom('smooth')` / ResizeObserver,沒被新加的 effect 干擾。

## Test plan

- [ ] `npm run serve:react-demo`,打開 http://localhost:4200/history-scroll-bug
- [ ] **Preview mode** (預設,含圖片 + 延後 300ms 注入):chatbot 打開瞬間就在底,看得到「🎯 BOTTOM」
- [ ] 點 `🔄 Reload Chatbot` 反覆 re-mount,每次都在底
- [ ] 取消勾「插入圖片訊息」:行為一致 (原本就會在底,確認沒退步)
- [ ] **勾「Mock SSE 模式」**:input 可送訊息,enter 後 bot 開始 streaming reply,過程中 scroll 持續貼底
- [ ] Mock 模式下中途手動往上滾 → `isFollowingLatest` 變 false → 後續 delta 不再強制追到底 (SDK 既有設計,確認沒被新加的 `useLayoutEffect` 干擾)
- [ ] 在其他既有 demo route (例如 `/templates`、`/custom-renderer`) 確認 initial 滾動沒有 regression