### PR TITLE
feat(core,react): display tool call reason as label when available

### DIFF
--- a/packages/core/src/lib/conversation.ts
+++ b/packages/core/src/lib/conversation.ts
@@ -147,6 +147,7 @@ export default class Conversation implements IConversation {
       processId: toolCallStart.processId,
       callSeq: toolCallStart.callSeq,
       toolName: toolCallStart.toolCall.toolName,
+      reason: toolCallStart.toolCall.reason,
       toolsetName: toolCallStart.toolCall.toolsetName,
       parameter: toolCallStart.toolCall.parameter,
       isComplete: false,

--- a/packages/core/src/types/channel.ts
+++ b/packages/core/src/types/channel.ts
@@ -58,6 +58,7 @@ export type ConversationToolCallMessage = {
   processId: string;
   callSeq: number;
   toolName: string;
+  reason?: string;
   toolsetName: string;
   parameter: Record<string, unknown>;
   result?: Record<string, unknown>;

--- a/packages/core/src/types/sse-response.ts
+++ b/packages/core/src/types/sse-response.ts
@@ -182,6 +182,7 @@ export interface ToolCallBaseEventData {
     toolsetName: string;
     toolName: string;
     parameter: Record<string, unknown>;
+    reason?: string;
   };
 }
 

--- a/packages/react/src/components/chatbot/chatbot-body/chatbot-body.tsx
+++ b/packages/react/src/components/chatbot/chatbot-body/chatbot-body.tsx
@@ -50,7 +50,7 @@ function toolCallToItemData(toolCall: ConversationToolCallMessage): ToolCallItem
 
   return {
     id: toolCall.messageId,
-    label: toolCall.toolName,
+    label: toolCall.reason || toolCall.toolName,
     status,
     initial: {
       toolsetName: toolCall.toolsetName,


### PR DESCRIPTION
## 說明

`asgard.tool_call.start` 事件的 `toolCall` 物件包含 `reason` 欄位，用來描述此次 tool call 的目的。

原本 tool call UI 的顯示文字固定使用 `toolName`（如 `bash`），現在改為：若 `reason` 不為空字串則顯示 `reason`，否則 fallback 為 `toolName`。

## 變更範圍

- `packages/core/src/types/sse-response.ts` — `ToolCallBaseEventData.toolCall` 加 `reason?: string`
- `packages/core/src/types/channel.ts` — `ConversationToolCallMessage` 加 `reason?: string`
- `packages/core/src/lib/conversation.ts` — `onToolCallStart` 傳入 `reason`
- `packages/react/src/components/chatbot/chatbot-body/chatbot-body.tsx` — `label` 改為 `toolCall.reason || toolCall.toolName`

## 關聯任務

https://app.clickup.com/t/86exr2q91