### PR TITLE
feat(core,react): display tool call reason in consent modal when available

### DIFF
--- a/packages/core/src/types/sse-response.ts
+++ b/packages/core/src/types/sse-response.ts
@@ -196,6 +196,7 @@ export interface ToolCallConsentPendingCall {
   toolName: string;
   parameter: Record<string, unknown>;
   alreadyAllowed: boolean;
+  reason?: string;
 }
 
 export interface ToolCallConsentEventData {

--- a/packages/react/src/components/tool-call-consent/tool-call-consent-modal.tsx
+++ b/packages/react/src/components/tool-call-consent/tool-call-consent-modal.tsx
@@ -103,7 +103,7 @@ export function ToolCallConsentModal(props: ToolCallConsentModalProps): ReactNod
       <div className={styles.modal} role="dialog" aria-modal="true">
         <div className={styles.header}>
           <div className={styles.title}>
-            允許使用工具 <span className={styles.title_tool}>「{pendingCall.toolName}」</span>？
+            允許使用工具 <span className={styles.title_tool}>「{pendingCall.reason || pendingCall.toolName}」</span>？
           </div>
           {onDismiss && (
             <button type="button" className={styles.close_btn} onClick={onDismiss} aria-label="關閉">


### PR DESCRIPTION
## 說明

`asgard.tool_call.consent` 事件的 `pendingCalls` 中每個元素包含 `reason` 欄位。

原本 consent modal 藍色引號文字固定顯示 `toolName`（技術名稱），現在改為：若 `reason` 不為空字串則顯示 `reason`（人話描述），否則 fallback 為 `toolName`。

## 變更範圍

- `packages/core/src/types/sse-response.ts` — `ToolCallConsentPendingCall` 加 `reason?: string`
- `packages/react/src/components/tool-call-consent/tool-call-consent-modal.tsx` — 引號文字改為 `pendingCall.reason || pendingCall.toolName`

## 關聯任務

https://app.clickup.com/t/86exr2rkq