### PR TITLE
fix(react): prevent dts from rewriting @asgard-js/core imports to monorepo paths

### DIFF
--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+      pathsToAliases: false,
     }),
   ],
   css: {


### PR DESCRIPTION
## 問題

`@asgard-js/react` 打包後的 `.d.ts` 檔案中，所有 `@asgard-js/core` 的 import 被替換為 monorepo 內部路徑（例如 `'../../../core/src/index.ts'`），導致消費端套件（包括 `asgard-testing-3` 等專案）在解析型別時找不到對應檔案。

```ts
// 修復前（錯誤）
import { FetchSsePayload } from '../../../core/src/index.ts';

// 修復後（正確）
import { FetchSsePayload } from '@asgard-js/core';
```

## 根本原因

`vite-plugin-dts` 的 `pathsToAliases` 選項預設為 `true`，會將 `tsconfig.lib.json` 中 `paths` 所定義的 `"@asgard-js/core": ["../core/src/index.ts"]` 這個對應關係套用到輸出的 `.d.ts` 檔案，把套件名稱替換成 monorepo 本地路徑。

## 修復

在 `vite.config.ts` 的 `dts()` 設定加上 `pathsToAliases: false`，保留 `@asgard-js/core` 原本的套件名稱，不做路徑替換。

## 影響範圍

所有使用 `@asgard-js/react` 且依賴 `@asgard-js/core` 型別的 `.d.ts` 均受此修復影響，包含 `use-channel.d.ts`、`chatbot.d.ts`、各 context 與 template `.d.ts` 等。