### PR TITLE
docs: fix factual errors in React and Core README

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -246,10 +246,10 @@ const conversation = new Conversation({ messages: new Map() });
 
 // Add a user message
 const userMessage = {
-  id: 'msg-1',
+  messageId: 'msg-1',
   type: 'user',
   text: 'Hello',
-  time: Date.now(),
+  time: new Date(),
 };
 
 const updatedConversation = conversation.pushMessage(userMessage);

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -66,7 +66,6 @@ const App = () => {
         enableLoadConfigFromService={true}
         customChannelId="your-channel-id"
         initMessages={[]}
-        debugMode={false}
         fullScreen={false}
         avatar="https://example.com/avatar.png"
         botTypingPlaceholder="Bot is typing..."
@@ -331,7 +330,7 @@ config: {
 - **renderMessageContent?**: `(props: MessageContentRendererProps) => ReactNode` - Custom renderer for message content. Allows customizing how messages are rendered based on message properties. See [Custom Message Renderer](#custom-message-renderer) section for details.
 - **renderToolCallGroup?**: `(props: ToolCallGroupRendererProps) => ReactNode` - Custom renderer for tool call group. Return `null` to hide, return JSX to fully customize, or call `renderDefaultContent()` to use the default UI with optional overrides (e.g., `renderDefaultContent({ title: 'AI is thinking...' })`). See [Tool Call Group Renderer](#tool-call-group-renderer) section for details.
 - **onBeforeSendMessage?**: `(params: SendMessageParams) => SendMessageParams` - Callback to modify message params before sending. Allows injecting contextual data (payload, metadata) from parent components. See [Before Send Message Hook](#before-send-message-hook) section for details.
-- **onSseMessage**: `(response: SseResponse, ctx: AsgardServiceContextValue) => void` - Callback function when SSE message is received. It would be helpful if using with the ref to provide some context and conversation data and do some proactively actions like sending messages to the bot.
+- **onSseMessage**: `(response: SseResponse, ctx: { conversation: Conversation | null }) => void` - Callback fired on every SSE message. `ctx.conversation` is the conversation state at the time the event fires. Combine with `ref.current.serviceContext.sendMessage` to trigger follow-up messages programmatically.
 - **ref**: `ForwardedRef<ChatbotRef>` - Forwarded ref to access the chatbot instance. It can be used to access the chatbot instance and do some actions like sending messages to the bot. `ChatbotRef` provides `serviceContext` for interacting with the chatbot, and `setInputValue(value: string)` for programmatically setting the textarea text from outside the component.
 
 <a id="theme-configuration"></a>


### PR DESCRIPTION
## 修正的錯誤

### 1. React README — `debugMode` 不是有效的 Chatbot prop

Basic Usage 範例中有 `debugMode={false}` 直接放在 `<Chatbot>` 上，但 `ChatbotProps` 沒有這個 prop（`debugMode` 只存在於 `config.debugMode`）。這行會被靜默忽略，誤導使用者。

### 2. React README — `onSseMessage` 的 `ctx` 型別錯誤

文件寫 `ctx: AsgardServiceContextValue`，但實際型別是 `ctx: { conversation: Conversation | null }`。使用者若依文件嘗試讀取 `ctx.sendMessage` 等屬性，會得到 undefined。

### 3. Core README — `pushMessage` 範例的欄位名稱與型別錯誤

範例物件使用了不存在的 `id` 欄位（應為 `messageId`），以及型別為 `number` 的 `Date.now()`（應為 `new Date()`，型別為 `Date`）。