### PR TITLE
fix(react): theme the chatbot textarea focus ring

### DIFF
--- a/packages/react/src/components/chatbot/chatbot-footer/chatbot-footer.module.scss
+++ b/packages/react/src/components/chatbot/chatbot-footer/chatbot-footer.module.scss
@@ -42,6 +42,14 @@
     color: var(--asg-color-text-placeholder);
   }
 
+  // Replace the browser's default (blue) focus ring with a theme-driven one.
+  // --asg-textarea-focus-color is set inline from the theme (see chatbot-footer.tsx),
+  // falling back to the SDK primary color when no theme value is provided.
+  &:focus {
+    outline: 2px solid var(--asg-textarea-focus-color, var(--asg-color-primary));
+    outline-offset: -1px;
+  }
+
   &.chatbot_textarea--focused {
     animation: prevent_ios_focus_scroll 0.01s;
   }

--- a/packages/react/src/components/chatbot/chatbot-footer/chatbot-footer.tsx
+++ b/packages/react/src/components/chatbot/chatbot-footer/chatbot-footer.tsx
@@ -55,7 +55,8 @@ export function ChatbotFooter({ footerEndActions }: ChatbotFooterProps = {}): Re
   } = useAsgardContext();
   const { data } = useAsgardAppInitializationContext();
 
-  const { chatbot } = useAsgardThemeContext();
+  const theme = useAsgardThemeContext();
+  const { chatbot } = theme;
 
   // Determine enableUpload: prioritize prop, then annotations
   const enableUpload = useMemo(() => {
@@ -613,8 +614,17 @@ export function ChatbotFooter({ footerEndActions }: ChatbotFooterProps = {}): Re
         '--asg-color-text-placeholder',
         chatbot.footer?.textArea?.['::placeholder']?.color ?? 'var(--asg-color-text-placeholder)',
       );
+
+      // Drive the textarea focus ring (see chatbot-footer.module.scss :focus) from
+      // the theme. A :focus pseudo class can't be set inline, so expose the color
+      // as a CSS variable. Priority: primaryComponent.mainColor, then the user-message
+      // color so consumers that only theme userMessage still get a matching accent.
+      const focusColor = chatbot.primaryComponent?.mainColor ?? theme.userMessage?.backgroundColor;
+      if (focusColor) {
+        textareaRef.current.style.setProperty('--asg-textarea-focus-color', String(focusColor));
+      }
     }
-  }, [chatbot.footer?.textArea]);
+  }, [chatbot.footer?.textArea, chatbot.primaryComponent?.mainColor, theme.userMessage?.backgroundColor]);
 
   return (
     <div ref={footerRef} className={clsx('asgard-chatbot-footer', styles.chatbot_footer)} style={footerStyles}>


### PR DESCRIPTION
## 問題

ClickUp [86exkfxpm](https://app.clickup.com/t/86exkfxpm)：Agent Hub（Odin 預覽）的對話框 focus 邊框是藍色，與 Odin 主色調（綠）不一致。

根因：SDK 的輸入框 `textarea` 完全沒有 `:focus` 樣式，露出瀏覽器預設的藍色 focus ring。而 theme 是以 inline style 套用，無法觸及 `:focus` 偽類，consumer（Odin）無法只靠現有 theme 改掉它。

> 同票的「使用者訊息泡泡藍色」已由 Odin 端自行修正（將 `userMessage.backgroundColor` 設為 `hsl(var(--primary))`），非 SDK 範圍。

## 修改

- `chatbot-footer.module.scss`：`.chatbot_textarea:focus` 改用主題色 outline（`var(--asg-textarea-focus-color, var(--asg-color-primary))`），取代瀏覽器預設 ring。
- `chatbot-footer.tsx`：沿用既有設定 placeholder 變數的 `setProperty` 機制，注入 `--asg-textarea-focus-color`，來源優先序 `primaryComponent.mainColor` → `userMessage.backgroundColor`。

Consumer 不需改動：Odin 本來就把 `userMessage.backgroundColor` 設為綠色，focus 邊框會自動跟著變綠；未設主題色者則 fallback 到 `--asg-color-primary`。

## 驗證

- 本機將此分支 `npm pack` 裝進 Odin（`asgard-ai-platform-web`）實測：預覽頁輸入框 focus 邊框由瀏覽器藍 `#005FCC` → Odin 綠 `#10B77F`（`outline: 2px solid`，變數解析為 `hsl(var(--primary))`）。
- 預設主題（react-demo）正確 fallback 到 `--asg-color-primary`。
- `build:core` / `build:react` 皆通過。
