### PR TITLE
docs: sync core and react package READMEs with SDK 0.2.62 API

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,7 +21,7 @@ npm install @asgard-js/core
 Here's a basic example of how to use the core package:
 
 ```javascript
-import { AsgardServiceClient } from '@asgard-js/core';
+import { AsgardServiceClient, FetchSseAction, EventType } from '@asgard-js/core';
 
 const client = new AsgardServiceClient({
   apiKey: 'your-api-key',
@@ -33,7 +33,7 @@ const client = new AsgardServiceClient({
 client.fetchSse({
   customChannelId: 'your-channel-id',
   text: 'Hello, Asgard!',
-  action: 'message',
+  action: FetchSseAction.NONE,
 });
 
 // Upload files (optional, requires uploadFile method)
@@ -51,7 +51,7 @@ if (client.uploadFile) {
       client.fetchSse({
         customChannelId: 'your-channel-id',
         text: 'Here is my image:',
-        action: 'message',
+        action: FetchSseAction.NONE,
         blobIds: [blobId],
       });
     }
@@ -61,15 +61,15 @@ if (client.uploadFile) {
 }
 
 // Listen to events
-client.on('MESSAGE', response => {
+client.on(EventType.MESSAGE, response => {
   console.log('Received message:', response);
 });
 
-client.on('DONE', response => {
+client.on(EventType.DONE, response => {
   console.log('Conversation completed:', response);
 });
 
-client.on('ERROR', error => {
+client.on(EventType.ERROR, error => {
   console.error('Error occurred:', error);
 });
 ```
@@ -114,7 +114,7 @@ const client = new AsgardServiceClient({
 
 ## API Reference
 
-The core package exports three main classes for different levels of abstraction and includes authentication types for dynamic API key management:
+The core package exports three main classes for different levels of abstraction (`AsgardServiceClient`, `Channel`, `Conversation`), an `HttpError` class with an `isHttpError` type guard for HTTP failure handling, and authentication types for dynamic API key management:
 
 <a id="asgardserviceclient"></a>
 <br/>
@@ -141,19 +141,24 @@ The main client class for interacting with the Asgard AI platform.
 
 #### Methods
 
-- **fetchSse(payload, options?)**: Send a message via Server-Sent Events
+- **fetchSse(payload, options?)**: Send a message via Server-Sent Events. `payload.action` is a `FetchSseAction` value — `NONE` for a normal message, `RESET_CHANNEL` to (re)initialize the channel, `RESPONSE_TOOL_CALL_CONSENT` to answer a consent prompt
 - **uploadFile(file, customChannelId)**: Upload file to Blob API and return BlobUploadResponse
-- **on(event, handler)**: Listen to specific SSE events
-- **close()**: Close the SSE connection and cleanup resources
+- **downloadCwdFile(relativePath, customChannelId)**: `Promise<CwdDownloadResult>` - Download a file from the channel sandbox working directory (backs `cwd://` URI actions); resolves to `{ blob, filename }`
+- **on(event, handler)**: Listen to a specific SSE event. `event` must be an `EventType` value (e.g. `EventType.MESSAGE`), not a plain string; registering a listener for an event replaces any previous one
+- **detach({ timeoutMs })**: Detach from the owning component without aborting in-flight runs — the connection stays open so the backend can finish the current run, then auto-closes once all runs settle (or after `timeoutMs` as a safety net). Backs the React `keepConnectionOnUnmount` prop
+- **close()**: Close the SSE connection and clean up resources (idempotent)
 
 #### Event Types
 
-- **INIT**: Run initialization events
-- **MESSAGE**: Message events (start, delta, complete)
-- **TOOL_CALL**: Tool call events (start, complete)
-- **PROCESS**: Process events (start, complete)
-- **DONE**: Run completion events
-- **ERROR**: Error events
+Pass these `EventType` members (imported from `@asgard-js/core`) as the first argument to `on()`:
+
+- **`EventType.INIT`** (`asgard.run.init`): Run initialization events
+- **`EventType.MESSAGE`** (`asgard.message`): Message events (start, delta, complete)
+- **`EventType.TOOL_CALL`** (`asgard.tool_call`): Tool call events (start, complete)
+- **`EventType.TOOL_CALL_CONSENT`** (`asgard.tool_call.consent`): Tool call consent prompts awaiting a user decision
+- **`EventType.PROCESS`** (`asgard.process`): Process events (start, complete)
+- **`EventType.DONE`** (`asgard.run.done`): Run completion events
+- **`EventType.ERROR`** (`asgard.run.error`): Error events
 
 <a id="channel"></a>
 <br/>
@@ -169,6 +174,7 @@ Higher-level abstraction for managing a conversation channel with reactive state
 #### Instance Methods
 
 - **sendMessage(payload, options?)**: `Promise<void>` - Send a message through the channel
+- **replyToolCallConsents(answers, options?, payload?)**: `Promise<void>` - Reply to a pending tool-call consent prompt. `answers` is an array of `ToolCallConsentAnswer` (each `{ toolCallId, result, denyReason }`, where `result` is a `ToolCallConsentResult` value)
 - **close()**: `void` - Close the channel and cleanup subscriptions
 
 #### Configuration (ChannelConfig)
@@ -219,21 +225,24 @@ Immutable conversation state manager that handles message updates and SSE event 
 
 #### Constructor
 
-- **constructor(options)**: Initialize conversation with `{messages: Map<string, ConversationMessage> | null}`
+- **constructor(options)**: Initialize conversation with `{ messages: Map<string, ConversationMessage> | null, pendingConsent?: ToolCallConsentEventData | null }`
 
 #### Methods
 
 - **pushMessage(message)**: `Conversation` - Add a new message (returns new instance)
-- **onMessage(response)**: `Conversation` - Process SSE response and update conversation
+- **onMessage(response)**: `Conversation` - Process an SSE response and update the conversation (returns new instance)
+- **clearPendingConsent()**: `Conversation` - Clear the pending tool-call consent (returns new instance)
 
 #### Properties
 
 - **messages**: `Map<string, ConversationMessage> | null` - Map of all messages in the conversation
+- **pendingConsent**: `ToolCallConsentEventData | null` - The tool-call consent prompt currently awaiting a user decision, or `null`
 
 #### Message Types
 
 - **ConversationUserMessage**: User-sent messages with `text` and `time`
 - **ConversationBotMessage**: Bot responses with `message`, `isTyping`, `typingText`, `eventType`
+- **ConversationToolCallMessage**: Tool-call entries with `toolName`, `reason`, `parameter`, `result`, `isComplete`
 - **ConversationErrorMessage**: Error messages with `error` details
 
 #### Example Usage
@@ -273,7 +282,7 @@ if (uploadResponse.isSuccess && uploadResponse.data[0]) {
   client.fetchSse({
     customChannelId: 'your-channel-id',
     text: 'Here is my image',
-    action: 'message',
+    action: FetchSseAction.NONE,
     blobIds: [blobId],
   });
 }
@@ -293,7 +302,14 @@ The core package includes authentication-related types for dynamic API key manag
 Authentication state management for applications requiring dynamic API key input:
 
 ```typescript
-type AuthState = 'loading' | 'needApiKey' | 'authenticated' | 'error' | 'invalidApiKey';
+type AuthState =
+  | 'loading'
+  | 'needApiKey'
+  | 'authenticated'
+  | 'error'
+  | 'invalidApiKey'
+  | 'subscriptionExpired'
+  | 'botNotFound';
 ```
 
 **States:**
@@ -303,6 +319,8 @@ type AuthState = 'loading' | 'needApiKey' | 'authenticated' | 'error' | 'invalid
 - **`authenticated`**: Successfully authenticated
 - **`error`**: General authentication error
 - **`invalidApiKey`**: API key is invalid
+- **`subscriptionExpired`**: The workspace subscription has expired
+- **`botNotFound`**: The configured bot provider could not be found
 
 **Usage:**
 
@@ -319,6 +337,63 @@ function handleAuthState(state: AuthState) {
       break;
     // Handle other states...
   }
+}
+```
+
+<a id="error-handling"></a>
+<br/>
+
+### Error Handling (HttpError)
+
+HTTP failures (for example a non-2xx response while authenticating) are surfaced as an `HttpError` instance. Both `HttpError` and the `isHttpError` type guard are re-exported from the package root:
+
+```typescript
+import { isHttpError } from '@asgard-js/core';
+
+try {
+  // ... a call that may reject with an HttpError
+} catch (error) {
+  if (isHttpError(error)) {
+    console.error(error.status, error.statusText, error.body);
+  }
+}
+```
+
+`HttpError` extends `Error` with readonly `status: number`, `statusText: string`, and `body: unknown` (its `name` is `'HttpError'`).
+
+<a id="tool-call-consent"></a>
+<br/>
+
+### Tool Call Consent
+
+When a bot is configured to ask before running a tool, the backend emits an `EventType.TOOL_CALL_CONSENT` event. The pending request is exposed on `Conversation.pendingConsent`; reply to it with `Channel.replyToolCallConsents()`:
+
+```typescript
+import { ToolCallConsentResult } from '@asgard-js/core';
+
+await channel.replyToolCallConsents([
+  { toolCallId: 'call-1', result: ToolCallConsentResult.ALLOW_ONCE, denyReason: '' },
+]);
+```
+
+**Related types:**
+
+- **`ToolCallConsentResult`** (enum): `ALLOW_ONCE` | `ALLOW_ALWAYS` | `DENY_ONCE`
+- **`ToolCallConsentPendingCall`**: `{ toolCallId, toolsetName, toolName, parameter, alreadyAllowed, reason? }`
+- **`ToolCallConsentEventData`**: `{ processId, pendingCalls: ToolCallConsentPendingCall[] }`
+- **`ToolCallConsentAnswer`**: `{ toolCallId, result, denyReason }`
+
+<a id="cwd-download-result"></a>
+<br/>
+
+### CwdDownloadResult
+
+Returned by `client.downloadCwdFile()`:
+
+```typescript
+interface CwdDownloadResult {
+  blob: Blob;
+  filename: string;
 }
 ```
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -141,6 +141,26 @@ When `enableLoadConfigFromService` is enabled, you can also control the upload f
 
 **Features**: Multiple file selection, image preview with modal view, and responsive design. Supports JPEG, PNG, GIF, WebP up to 20MB per file, maximum 10 files at once.
 
+#### Restricting Allowed MIME Types
+
+By default, image upload accepts `image/jpeg`, `image/jpg`, `image/png`, `image/gif`, and `image/webp`, while document upload accepts a built-in list of document types (with an extension-based fallback). To narrow — or extend — what users may attach, pass `allowedImageMimeTypes` / `allowedDocumentMimeTypes`:
+
+```javascript
+<Chatbot
+  config={{
+    apiKey: 'your-api-key',
+    botProviderEndpoint: 'https://api.asgard-ai.com/ns/{namespace}/bot-provider/{botProviderId}',
+  }}
+  customChannelId="your-channel-id"
+  enableUpload
+  enableDocumentUpload
+  allowedImageMimeTypes={['image/png', 'image/webp']}
+  allowedDocumentMimeTypes={['application/pdf']}
+/>
+```
+
+Both props **override** their respective default list entirely (they do not merge) and only take effect when the matching `enableUpload` / `enableDocumentUpload` flag is on. The provided values drive both the file picker `accept` attribute and validation. For documents, supplying the prop also switches validation to MIME-only matching (the extension fallback no longer applies). Passing an empty array is treated the same as omitting the prop.
+
 <a id="conversation-export"></a>
 <br/>
 
@@ -295,6 +315,8 @@ config: {
 - **enableUpload?**: `boolean` - Enable file upload functionality. When set, it takes priority over the `embedConfig.enableUpload` setting from the bot provider metadata. Defaults to `false` if not specified in either location. Supports image files (JPEG, PNG, GIF, WebP) up to 20MB per file, maximum 10 files at once.
 - **enableExport?**: `boolean` - Enable conversation export functionality. When set, it takes priority over the `embedConfig.enableExport` setting from the bot provider metadata. Defaults to `false` if not specified in either location. Adds a download button to the chatbot footer that exports the conversation history as a Markdown file with timestamps and trace IDs.
 - **enableDocumentUpload?**: `boolean` - Enable document file upload functionality. When enabled, users can attach document files to messages. The container-level drag-and-drop overlay is also activated. Defaults to `false`.
+- **allowedImageMimeTypes?**: `string[]` - Restrict which image MIME types can be uploaded when `enableUpload` is on. When provided, it **overrides** the default image list entirely (values are used as-is for both the file picker `accept` and validation, and may include types outside the SDK defaults). When omitted or empty, all default image types are accepted (`image/jpeg`, `image/jpg`, `image/png`, `image/gif`, `image/webp`).
+- **allowedDocumentMimeTypes?**: `string[]` - Restrict which document MIME types can be uploaded when `enableDocumentUpload` is on. When provided, it **overrides** the default document list entirely and validation switches to MIME-only matching (the extension-based fallback is dropped). When omitted or empty, the default document list with extension fallback is used.
 - **maintainConnectionWhenClosed?**: `boolean` - Maintain connection when chat is closed, defaults to `false`
 - **keepConnectionOnUnmount?**: `boolean` - Keep the in-flight SSE run alive when the chatbot unmounts (e.g. the user navigates to another in-app page) instead of aborting it, so that round can finish on the backend. The detached connection cleans itself up once the run completes, or after a safety timeout if it never finishes. Only covers in-app unmounts — a full page reload / tab close / network loss still tears the connection down. Defaults to `false`
 - **loadingComponent?**: `ReactNode` - Custom loading component
@@ -315,7 +337,7 @@ config: {
 - **onChannelReady?**: `() => void` - Callback fired once the chat channel is ready to accept messages. Use this instead of polling for `sendMessage` availability when you need to send an initial message right after the chatbot mounts. Re-fires after channel reset. See [On Channel Ready](#on-channel-ready) section for details.
 - **onReset**: `() => void` - Callback function when chat is reset
 - **onClose**: `() => void` - Callback function when chat is closed
-- **authState?**: `AuthState` - Authentication state for dynamic API key management. Available states: `'loading'`, `'needApiKey'`, `'authenticated'`, `'error'`, `'invalidApiKey'`
+- **authState?**: `AuthState` - Authentication state for dynamic API key management. Available states: `'loading'`, `'needApiKey'`, `'authenticated'`, `'error'`, `'invalidApiKey'`, `'subscriptionExpired'`, `'botNotFound'`
 - **onApiKeySubmit?**: `(apiKey: string) => Promise<void>` - Callback function when user submits API key for authentication
 - **onAuthError?**: `(error: { isAuthError: boolean; isBotProviderError: boolean; errorDetail?: unknown }) => void` - Callback fired when authentication or bot provider initialization fails. Useful for logging or showing a custom error UI.
 - **onSseError?**: `(error: unknown) => void` - Callback fired when the SSE connection encounters an error.
@@ -624,33 +646,41 @@ function MyCustomFooter() {
 
 **State**
 
-| Property               | Type                                       | Description                                                                                                                                                                   |
-| ---------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `avatar`               | `string \| undefined`                      | Avatar URL passed to the Chatbot, or loaded from the bot provider metadata.                                                                                                   |
-| `title`                | `string \| undefined`                      | Chatbot title passed to the Chatbot, or loaded from the bot provider metadata.                                                                                                |
-| `isOpen`               | `boolean`                                  | Whether the chatbot is currently open/visible.                                                                                                                                |
-| `isResetting`          | `boolean`                                  | Whether a channel reset is in progress. Use to disable reset buttons during reset.                                                                                            |
-| `isConnecting`         | `boolean`                                  | Whether the SSE channel is currently processing a message. Use to disable the send button.                                                                                    |
-| `messages`             | `Map<string, ConversationMessage> \| null` | All messages in the current conversation. `null` before the channel is initialized.                                                                                           |
-| `botTypingPlaceholder` | `string \| undefined`                      | Typing indicator text (from props or bot provider metadata).                                                                                                                  |
-| `inputPlaceholder`     | `string \| undefined`                      | Textarea placeholder text (from props or bot provider metadata).                                                                                                              |
-| `enableUpload`         | `boolean \| undefined`                     | Whether image upload is enabled (resolved from props / bot provider metadata).                                                                                                |
-| `enableExport`         | `boolean \| undefined`                     | Whether conversation export is enabled.                                                                                                                                       |
-| `enableDocumentUpload` | `boolean \| undefined`                     | Whether document upload is enabled.                                                                                                                                           |
-| `isFollowingLatest`    | `boolean`                                  | Whether auto-scroll to the latest message is active. Becomes `false` when the user scrolls up.                                                                                |
-| `pendingInputValue`    | `string \| null`                           | Text waiting to be filled into the textarea. Set by `ChatbotRef.setInputValue()` or by `renderMenu`. Read and clear this in `renderFooter` to receive externally pushed text. |
+| Property                   | Type                                       | Description                                                                                                                                                                   |
+| -------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `avatar`                   | `string \| undefined`                      | Avatar URL passed to the Chatbot, or loaded from the bot provider metadata.                                                                                                   |
+| `title`                    | `string \| undefined`                      | Chatbot title passed to the Chatbot, or loaded from the bot provider metadata.                                                                                                |
+| `client`                   | `AsgardServiceClient \| null`              | The underlying core client instance, or `null` before the channel is initialized.                                                                                             |
+| `customChannelId`          | `string \| undefined`                      | The active channel identifier.                                                                                                                                                |
+| `isOpen`                   | `boolean`                                  | Whether the chatbot is currently open/visible.                                                                                                                                |
+| `isResetting`              | `boolean`                                  | Whether a channel reset is in progress. Use to disable reset buttons during reset.                                                                                            |
+| `isConnecting`             | `boolean`                                  | Whether the SSE channel is currently processing a message. Use to disable the send button.                                                                                    |
+| `messages`                 | `Map<string, ConversationMessage> \| null` | All messages in the current conversation. `null` before the channel is initialized.                                                                                           |
+| `botTypingPlaceholder`     | `string \| undefined`                      | Typing indicator text (from props or bot provider metadata).                                                                                                                  |
+| `inputPlaceholder`         | `string \| undefined`                      | Textarea placeholder text (from props or bot provider metadata).                                                                                                              |
+| `enableUpload`             | `boolean \| undefined`                     | Whether image upload is enabled (resolved from props / bot provider metadata).                                                                                                |
+| `enableExport`             | `boolean \| undefined`                     | Whether conversation export is enabled.                                                                                                                                       |
+| `enableDocumentUpload`     | `boolean \| undefined`                     | Whether document upload is enabled.                                                                                                                                           |
+| `allowedImageMimeTypes`    | `string[] \| undefined`                    | Resolved image MIME allow-list (from the `allowedImageMimeTypes` prop). `undefined` means all defaults are accepted.                                                          |
+| `allowedDocumentMimeTypes` | `string[] \| undefined`                    | Resolved document MIME allow-list (from the `allowedDocumentMimeTypes` prop). `undefined` means the default list with extension fallback is used.                             |
+| `pendingConsent`           | `ToolCallConsentEventData \| null`         | The pending tool-call consent prompt awaiting a user decision, or `null`. Read this to build a custom consent UI.                                                             |
+| `messageBoxBottomRef`      | `RefObject<HTMLDivElement \| null>`        | Ref to the sentinel element at the bottom of the message list.                                                                                                                |
+| `scrollContainerRef`       | `RefObject<HTMLDivElement \| null>`        | Ref to the scrollable message container.                                                                                                                                      |
+| `isFollowingLatest`        | `boolean`                                  | Whether auto-scroll to the latest message is active. Becomes `false` when the user scrolls up.                                                                                |
+| `pendingInputValue`        | `string \| null`                           | Text waiting to be filled into the textarea. Set by `ChatbotRef.setInputValue()` or by `renderMenu`. Read and clear this in `renderFooter` to receive externally pushed text. |
 
 **Actions**
 
-| Property                     | Type                                                          | Description                                                                                                                       |
-| ---------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `sendMessage`                | `((params: SendMessageParams) => Promise<void>) \| undefined` | Send a message through the channel. `undefined` while the channel is not yet ready or in preview mode — always guard with `?.()`. |
-| `resetChannel`               | `(() => void) \| undefined`                                   | Reset the channel (triggers a new welcome message from the bot).                                                                  |
-| `closeChannel`               | `(() => void) \| undefined`                                   | Close the SSE connection without resetting.                                                                                       |
-| `scrollToBottom`             | `(behavior?: ScrollBehavior) => void`                         | Scroll the message list to the bottom. Also resumes auto-scroll (`isFollowingLatest → true`).                                     |
-| `programmaticScrollToBottom` | `(behavior?: ScrollBehavior) => void`                         | Scroll to bottom without affecting `isFollowingLatest`.                                                                           |
-| `setFollowingLatest`         | `(value: boolean) => void`                                    | Manually set auto-scroll state.                                                                                                   |
-| `setPendingInputValue`       | `(value: string \| null) => void`                             | Push text into the textarea from outside. Clear it (`null`) after reading in `renderFooter`.                                      |
+| Property                     | Type                                                            | Description                                                                                                                                       |
+| ---------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sendMessage`                | `((params: SendMessageParams) => Promise<void>) \| undefined`   | Send a message through the channel. `undefined` while the channel is not yet ready or in preview mode — always guard with `?.()`.                 |
+| `resetChannel`               | `(() => void) \| undefined`                                     | Reset the channel (triggers a new welcome message from the bot).                                                                                  |
+| `closeChannel`               | `(() => void) \| undefined`                                     | Close the SSE connection without resetting.                                                                                                       |
+| `replyToolCallConsents`      | `((answers, options?, payload?) => Promise<void>) \| undefined` | Reply to the pending tool-call consent prompt (see `pendingConsent`). Used to build a custom consent UI. `undefined` before the channel is ready. |
+| `scrollToBottom`             | `(behavior?: ScrollBehavior) => void`                           | Scroll the message list to the bottom. Also resumes auto-scroll (`isFollowingLatest → true`).                                                     |
+| `programmaticScrollToBottom` | `(behavior?: ScrollBehavior) => void`                           | Scroll to bottom without affecting `isFollowingLatest`.                                                                                           |
+| `setFollowingLatest`         | `(value: boolean) => void`                                      | Manually set auto-scroll state.                                                                                                                   |
+| `setPendingInputValue`       | `(value: string \| null) => void`                               | Push text into the textarea from outside. Clear it (`null`) after reading in `renderFooter`.                                                      |
 
 <a id="event-handlers"></a>
 <br/>


### PR DESCRIPTION
## 背景

SDK 已迭代到 **0.2.62**，但 `@asgard-js/core` 與 `@asgard-js/react` 的 package README 與實際原始碼出現漂移：有兩個會直接壞掉的範例，以及多個已出貨但完全沒寫進文件的公開 API。本 PR 以**原始碼為準**校正 README（不改任何程式邏輯，純文件）。

## core README

**修正會壞掉的範例（P0）**
- `fetchSse({ action: 'message' })` —— `'message'` 不是合法的 `FetchSseAction`，一般訊息應為 `FetchSseAction.NONE`（三處範例）。
- `client.on('MESSAGE' / 'DONE' / 'ERROR', …)` —— `on()` 的 key 是 `EventType` 的**值**（如 `'asgard.message'`），字串 `'MESSAGE'` 註冊到不存在的 key，listener **永遠不會觸發**。改為 `EventType.MESSAGE` 等，並在範例 import 補上 `FetchSseAction` / `EventType`。

**補上漏掉的公開 API**
- `downloadCwdFile()` / `CwdDownloadResult`、`detach({ timeoutMs })`、`close()` 冪等說明。
- Tool-call consent 介面：`EventType.TOOL_CALL_CONSENT`、`Channel.replyToolCallConsents()`、`ToolCallConsentResult` enum 與相關型別。
- `HttpError` class 與 `isHttpError` type guard，並修正「exports three main classes」的描述。
- `AuthState` 補齊為 7 個值（新增 `subscriptionExpired`、`botNotFound`）。
- `Conversation` 補上 `pendingConsent`、`clearPendingConsent()`、`ConversationToolCallMessage`。

## react README

- 補上 **0.2.62 新增**的 `allowedImageMimeTypes` / `allowedDocumentMimeTypes` props（props 清單、File Upload 段、`useAsgardContext()` 表），並說明「覆蓋而非合併」語意。
- `authState` prop 的 available states 補齊為 7 個值。
- `useAsgardContext()` 參考表補上 `client`、`pendingConsent`、`replyToolCallConsents`、MIME allow-list 與 scroll refs。

## 驗證

- `npx prettier --check` 對兩個 README 通過（表格欄寬已重新對齊）。
- 所有改動皆比對原始碼確認：`packages/core/src/{constants/enum.ts,types/client.ts,types/auth.ts,types/http-error.ts,lib/client.ts,lib/channel.ts,lib/conversation.ts}` 與 `packages/react/src/{components/chatbot/chatbot.tsx,context/asgard-service-context.tsx,utils/file-validation.ts}`。
- 純文件變更，不影響 build。